### PR TITLE
ENH: .minute_to_session_label out-of-bounds error handling

### DIFF
--- a/exchange_calendars/exchange_calendar.py
+++ b/exchange_calendars/exchange_calendar.py
@@ -962,7 +962,14 @@ class ExchangeCalendar(ABC):
             return current_or_next_session
         elif direction == "previous":
             if not self.is_open_on_minute(dt, ignore_breaks=True):
-                return self.schedule.index[idx - 1]
+                if dt < self.opens[0].value:
+                    raise ValueError(
+                        "No previous session available as '{0}'"
+                        " is earlier than the first calendar minute"
+                        " ({1})".format(pd.Timestamp(dt), self.opens[0])
+                    )
+                else:
+                    return self.schedule.index[idx - 1]
         elif direction == "none":
             if not self.is_open_on_minute(dt):
                 # if the exchange is closed, blow up

--- a/exchange_calendars/exchange_calendar.py
+++ b/exchange_calendars/exchange_calendar.py
@@ -363,6 +363,14 @@ class ExchangeCalendar(ABC):
     def early_closes(self):
         return self._early_closes
 
+    @property
+    def break_starts(self):
+        return self.schedule.break_start
+
+    @property
+    def break_ends(self):
+        return self.schedule.break_end
+
     def is_session(self, dt):
         """
         Given a dt, returns whether it's a valid session label.

--- a/exchange_calendars/exchange_calendar.py
+++ b/exchange_calendars/exchange_calendar.py
@@ -910,6 +910,16 @@ class ExchangeCalendar(ABC):
     def last_session(self):
         return self.all_sessions[-1]
 
+    @property
+    def first_session_open(self):
+        """Open time of calendar's first session."""
+        return self.opens[0]
+
+    @property
+    def last_session_close(self):
+        """Close time of calendar's last session."""
+        return self.closes[-1]
+    
     def execution_time_from_open(self, open_dates):
         return open_dates
 
@@ -947,7 +957,7 @@ class ExchangeCalendar(ABC):
             "previous" means that if the given dt is not part of a session,
             return the label of the previous session.
 
-            "none" means that a KeyError will be raised if the given
+            "none" means that a ValueError will be raised if the given
             dt is not part of a session.
 
         Returns
@@ -962,6 +972,33 @@ class ExchangeCalendar(ABC):
             if self._minute_to_session_label_cache[0] == dt:
                 return self._minute_to_session_label_cache[1]
 
+        if dt < self.first_session_open.value:
+            # Resolve call here.
+            if direction == "next":
+                self._minute_to_session_label_cache = (dt, self.first_session)
+                return self.first_session
+            else:
+                raise ValueError(
+                    "Received `dt` as '{0}' although this is earlier than the"
+                    " first session's open ({1}). Consider passing `direction`"
+                    " as 'next' to get first session label.".format(
+                        pd.Timestamp(dt, tz="UTC"), self.first_session_open
+                    )
+                )
+
+        if dt > self.last_session_close.value:
+            # Resolve call here.
+            if direction == "previous":
+                return self.last_session
+            else:
+                raise ValueError(
+                    "Received `dt` as '{0}' although this is later than the"
+                    " last session's close ({1}). Consider passing `direction`"
+                    " as 'previous' to get last session label.".format(
+                        pd.Timestamp(dt, tz="UTC"), self.last_session_close
+                    )
+                )
+            
         idx = searchsorted(self.market_closes_nanos, dt)
         current_or_next_session = self.schedule.index[idx]
 
@@ -970,18 +1007,14 @@ class ExchangeCalendar(ABC):
             return current_or_next_session
         elif direction == "previous":
             if not self.is_open_on_minute(dt, ignore_breaks=True):
-                if dt < self.opens[0].value:
-                    raise ValueError(
-                        "No previous session available as '{0}'"
-                        " is earlier than the first calendar minute"
-                        " ({1})".format(pd.Timestamp(dt), self.opens[0])
-                    )
-                else:
-                    return self.schedule.index[idx - 1]
+                return self.schedule.index[idx - 1]
         elif direction == "none":
             if not self.is_open_on_minute(dt):
                 # if the exchange is closed, blow up
-                raise ValueError("The given dt is not an exchange minute!")
+                raise ValueError(
+                    "Received `dt` as '{0}' although this is not an exchange"
+                    " minute.".format(pd.Timestamp(dt, tz="UTC"))
+                )
         else:
             # invalid direction
             raise ValueError(

--- a/exchange_calendars/exchange_calendar.py
+++ b/exchange_calendars/exchange_calendar.py
@@ -919,7 +919,7 @@ class ExchangeCalendar(ABC):
     def last_session_close(self):
         """Close time of calendar's last session."""
         return self.closes[-1]
-    
+
     def execution_time_from_open(self, open_dates):
         return open_dates
 
@@ -998,7 +998,7 @@ class ExchangeCalendar(ABC):
                         pd.Timestamp(dt, tz="UTC"), self.last_session_close
                     )
                 )
-            
+
         idx = searchsorted(self.market_closes_nanos, dt)
         current_or_next_session = self.schedule.index[idx]
 

--- a/tests/test_exchange_calendar.py
+++ b/tests/test_exchange_calendar.py
@@ -407,7 +407,7 @@ class ExchangeCalendarTestBase(object):
     def test_minute_to_session_label(self):
         # minute is prior to first session's open
         minute_before_first_open = self.answers.iloc[0].market_open - self.one_minute
-        session_label = answers.index[0]
+        session_label = self.answers.index[0]
         minutes_that_resolve_to_this_session = [
             self.calendar.minute_to_session_label(minute_before_first_open),
             self.calendar.minute_to_session_label(
@@ -540,10 +540,10 @@ class ExchangeCalendarTestBase(object):
                     self.calendar.minute_to_session_label(
                         minute_before_session, direction="none"
                     )
-        
+
         # minute is later than last session's close
         minute_after_last_close = self.answers.iloc[-1].market_close + self.one_minute
-        session_label = answers.index[-1]
+        session_label = self.answers.index[-1]
 
         minute_that_resolves_to_session_label = self.calendar.minute_to_session_label(
             minute_after_last_close, direction='previous'


### PR DESCRIPTION
Fixes issue #13.

Raise ValueError if `direction` is 'previous' and `dt` is earlier than first calendar minute.