### PR TITLE
ENH: Update xses holidays, adds 2021

### DIFF
--- a/exchange_calendars/calendar_helpers.py
+++ b/exchange_calendars/calendar_helpers.py
@@ -1,12 +1,23 @@
+from __future__ import annotations
+import typing
+import datetime
+
 import numpy as np
 import pandas as pd
+
+from exchange_calendars import errors
+
+if typing.TYPE_CHECKING:
+    from exchange_calendars import ExchangeCalendar
 
 NANOSECONDS_PER_MINUTE = int(6e10)
 
 NP_NAT = np.array([pd.NaT], dtype=np.int64)[0]
 
+Session = typing.Union[pd.Timestamp, str, int, float, datetime.datetime]
 
-def next_divider_idx(dividers, minute_val):
+
+def next_divider_idx(dividers: np.ndarray, minute_val: int) -> int:
 
     divider_idx = np.searchsorted(dividers, minute_val, side="right")
     target = dividers[divider_idx]
@@ -18,7 +29,7 @@ def next_divider_idx(dividers, minute_val):
         return divider_idx
 
 
-def previous_divider_idx(dividers, minute_val):
+def previous_divider_idx(dividers: np.ndarray, minute_val: int) -> int:
 
     divider_idx = np.searchsorted(dividers, minute_val)
 
@@ -29,11 +40,11 @@ def previous_divider_idx(dividers, minute_val):
 
 
 def compute_all_minutes(
-    opens_in_ns,
-    break_starts_in_ns,
-    break_ends_in_ns,
-    closes_in_ns,
-):
+    opens_in_ns: np.ndarray,
+    break_starts_in_ns: np.ndarray,
+    break_ends_in_ns: np.ndarray,
+    closes_in_ns: np.ndarray,
+) -> np.ndarray:
     """
     Given arrays of opens and closes (in nanoseconds) and optionally
     break_starts and break ends, return an array of each minute between the
@@ -71,3 +82,96 @@ def compute_all_minutes(
             )
     out = np.concatenate(pieces).view("datetime64[ns]")
     return out
+
+
+def parse_session(
+    calendar: ExchangeCalendar,
+    session: Session,
+    param_name: str | None = None,
+    strict: bool = True,
+) -> pd.Timestamp:
+    """Parse input intended to represent a session label.
+
+    Parameters
+    ----------
+    calendar :
+        Calendar against which to evaluate `session`.
+
+    session :
+        Input to be parsed to session label. Must be valid input to
+        pd.Timestamp and have a time component of 00:00.
+
+    param_name : optional
+        Name of a parameter receiving a session label. If passed
+        then error message will make reference to the parameter by name.
+
+    strict : default: True
+        Determines behaviour if `session` parses as UTC midnight although
+        is not a session of `calendar`.
+            True - raise NotSessionError.
+            False - return UTC midnight pd.Timestamp that does not
+            represent a session.
+
+    Returns
+    -------
+    pd.Timestamp
+        pd.Timestamp (UTC with time component of 00:00). If `strict` True
+        then return will represent a session of `calendar`.
+
+    Raises
+    ------
+    TypeError
+        If `session` is not of type pd.Timestamp | str | int | float |
+            datetime.datetime.
+
+    ValueError
+        If `session` is not an acceptable single-argument input to
+        pd.Timestamp.
+
+        If `session` time component is not 00:00.
+
+        If `session` is timezone aware and timezone is not UTC.
+
+    exchange_calendars.errors.NotSessionError
+        If `strict` True and `session` parses to a valid representation of
+        a session label although it is not a session of `calendar`.
+    """
+    try:
+        ts = pd.Timestamp(session)
+    except Exception:
+        insert = (
+            "received" if param_name is None else f"'{param_name}' received as"
+        )
+        msg = (
+            "A session label must be passed as a pd.Timestamp or a valid"
+            " single-argument input to pd.Timestamp although"
+            f" {insert} '{session}'."
+        )
+        if isinstance(
+            session, (pd.Timestamp, str, int, float, datetime.datetime)
+        ):
+            raise ValueError(msg) from None
+        else:
+            raise TypeError(msg) from None
+
+    if not (ts.tz is None or ts.tz.zone == "UTC"):
+        insert = " " if param_name is None else f" '{param_name}' "
+        raise ValueError(
+            "A session label must be timezone naive or have timezone"
+            f" as 'UTC', although{insert}parsed as '{ts}'."
+        )
+
+    if not ts == ts.normalize():
+        insert = " " if param_name is None else f" '{param_name}' "
+        raise ValueError(
+            "A session label must have a time component of 00:00"
+            f" although{insert}parsed as '{ts}'."
+        )
+
+    if ts.tz is None:
+        ts = ts.tz_localize("UTC")
+
+    if strict and not calendar.is_session(ts):
+        raise errors.NotSessionError(calendar, ts, param_name)
+    else:
+        return ts

--- a/exchange_calendars/exchange_calendar.py
+++ b/exchange_calendars/exchange_calendar.py
@@ -429,8 +429,12 @@ class ExchangeCalendar(ABC):
         bool
             True if any calendar session has a break, false otherwise.
         """
-        start = start if start is None else parse_session(self, start, "start")
-        end = end if end is None else parse_session(self, end, "end")
+        start = start if start is None else parse_session(
+            self, start, "start", strict=False
+        )
+        end = end if end is None else parse_session(
+            self, end, "end", strict=False
+        )
         return self.break_starts[start:end].notna().any()
 
     def is_open_on_minute(self, dt, ignore_breaks=False):

--- a/exchange_calendars/exchange_calendar_xses.py
+++ b/exchange_calendars/exchange_calendar_xses.py
@@ -351,6 +351,17 @@ precomputed_ses_holidays = pd.to_datetime(
         "2020-07-31",
         "2020-08-10",
         "2020-12-25",
+        "2021-01-01",  # New Year's Day
+        "2021-02-12",  # Chinese New Year  TODO: 2021-02-11 is half day
+        "2021-02-13",  # Chinese New Year
+        "2021-04-02",  # Good Friday
+        "2021-05-01",  # Labour Day
+        "2021-05-13",  # Hari Raya Puasa
+        "2021-05-26",  # Vesak Day
+        "2021-07-20",  # Hari Raya Haji
+        "2021-08-09",  # National Day
+        "2021-11-04",  # Deepavali
+        "2021-12-25",  # Christmas Day. TODO: 2021-12-24 and 2021-12-31 are half days
     ]
 )
 
@@ -369,6 +380,12 @@ class XSESExchangeCalendar(PrecomputedExchangeCalendar):
 
     TODO: There are a handful of half-days (day before Chinese New Year,
     Christmas Eve, etc.). We will add those later.
+
+    References
+    ----------
+    Accessed 2021-06-11 for 2021 holidays:
+        https://www.sgx.com/securities/trading#Trading%20Hours%20&%20Opening/Closing%20Routine
+        https://www.mom.gov.sg/employment-practices/public-holidays
     """
 
     name = "XSES"

--- a/tests/test_calendar_helpers.py
+++ b/tests/test_calendar_helpers.py
@@ -10,7 +10,7 @@ from exchange_calendars import errors
 
 # pylint: disable=missing-function-docstring,redefined-outer-name
 
-# TODO tests for next_divider_idx, previous_divider_idx, compute_all_minutes
+# TODO tests for next_divider_idx, previous_divider_idx, compute_all_minutes (#15)
 
 
 @pytest.fixture
@@ -49,41 +49,41 @@ def test_parse_session_invalid_session_input(
 
     session = "not valid input"
     with pytest.raises(ValueError):
-        m.parse_session(xnys_cal, session, name)
+        m.parse_session(session, name, xnys_cal)
 
     session = ["not", "valid", "input"]
     with pytest.raises(TypeError):
-        m.parse_session(xnys_cal, session, name)
+        m.parse_session(session, name, xnys_cal)
 
     session = pd.Timestamp("2021-06-07", tz="US/Central")
     with pytest.raises(
         ValueError, match="A session label must be timezone naive or"
     ):
-        m.parse_session(xnys_cal, session, name)
+        m.parse_session(session, name, xnys_cal)
 
     session = pd.Timestamp("2021-06-07 13:33")
     with pytest.raises(
         ValueError, match="A session label must have a time component of 00:00"
     ):
-        m.parse_session(xnys_cal, session, name)
+        m.parse_session(session, name, xnys_cal)
 
     with pytest.raises(
         errors.NotSessionError,
         match="is not a session of calendar",
     ):
-        m.parse_session(xnys_cal, xnys_nonsession, name, strict=True)
+        m.parse_session(xnys_nonsession, name, xnys_cal, strict=True)
 
     with pytest.raises(
         errors.NotSessionError,
         match="is earlier than the first session of calendar",
     ):
-        m.parse_session(xnys_cal, xnys_session_too_early, name, strict=True)
+        m.parse_session(xnys_session_too_early, name, xnys_cal, strict=True)
 
     with pytest.raises(
         errors.NotSessionError,
         match="is later than the last session of calendar",
     ):
-        m.parse_session(xnys_cal, xnys_session_too_late, name, strict=True)
+        m.parse_session(xnys_session_too_late, name, xnys_cal, strict=True)
 
 
 @pytest.mark.parametrize(
@@ -95,7 +95,7 @@ def test_parse_session_invalid_session_input(
     ],
 )
 def test_parse_session_valid_session_input(xnys_cal, session):
-    parsed_session = m.parse_session(xnys_cal, session)
+    parsed_session = m.parse_session(session, calendar=xnys_cal)
     assert isinstance(parsed_session, pd.Timestamp)
     assert parsed_session.tz.zone == "UTC"
     assert parsed_session == parsed_session.normalize()
@@ -103,7 +103,9 @@ def test_parse_session_valid_session_input(xnys_cal, session):
 
 
 def test_parse_session_valid_nonsession_input(xnys_cal, xnys_nonsession):
-    parsed_session = m.parse_session(xnys_cal, xnys_nonsession, strict=False)
+    parsed_session = m.parse_session(
+        xnys_nonsession, calendar=xnys_cal, strict=False
+    )
     assert isinstance(parsed_session, pd.Timestamp)
     assert parsed_session.tz.zone == "UTC"
     assert parsed_session == parsed_session.normalize()

--- a/tests/test_calendar_helpers.py
+++ b/tests/test_calendar_helpers.py
@@ -1,0 +1,110 @@
+"""Tests for calendar_helpers module."""
+
+from __future__ import annotations
+import pytest
+import pandas as pd
+
+import exchange_calendars
+from exchange_calendars import calendar_helpers as m
+from exchange_calendars import errors
+
+# pylint: disable=missing-function-docstring,redefined-outer-name
+
+# TODO tests for next_divider_idx, previous_divider_idx, compute_all_minutes
+
+
+@pytest.fixture
+def xnys_cal() -> exchange_calendars.ExchangeCalendar:
+    yield exchange_calendars.get_calendar("XNYS")
+
+
+@pytest.fixture
+def xnys_nonsession() -> pd.Timestamp:
+    yield pd.Timestamp("2021-06-06")  # sunday
+
+
+@pytest.fixture
+def xnys_session_too_early(xnys_cal) -> pd.Timestamp:
+    yield xnys_cal.first_session - pd.Timedelta(1, "D")
+
+
+@pytest.fixture
+def xnys_session_too_late(xnys_cal) -> pd.Timestamp:
+    yield xnys_cal.last_session + pd.Timedelta(1, "D")
+
+
+@pytest.fixture(params=["parameter_name", None])
+def param_name_options(request) -> str | None:
+    yield request.param
+
+
+def test_parse_session_invalid_session_input(
+    xnys_cal,
+    param_name_options,
+    xnys_nonsession,
+    xnys_session_too_early,
+    xnys_session_too_late,
+):
+    name = param_name_options
+
+    session = "not valid input"
+    with pytest.raises(ValueError):
+        m.parse_session(xnys_cal, session, name)
+
+    session = ["not", "valid", "input"]
+    with pytest.raises(TypeError):
+        m.parse_session(xnys_cal, session, name)
+
+    session = pd.Timestamp("2021-06-07", tz="US/Central")
+    with pytest.raises(
+        ValueError, match="A session label must be timezone naive or"
+    ):
+        m.parse_session(xnys_cal, session, name)
+
+    session = pd.Timestamp("2021-06-07 13:33")
+    with pytest.raises(
+        ValueError, match="A session label must have a time component of 00:00"
+    ):
+        m.parse_session(xnys_cal, session, name)
+
+    with pytest.raises(
+        errors.NotSessionError,
+        match="is not a session of calendar",
+    ):
+        m.parse_session(xnys_cal, xnys_nonsession, name, strict=True)
+
+    with pytest.raises(
+        errors.NotSessionError,
+        match="is earlier than the first session of calendar",
+    ):
+        m.parse_session(xnys_cal, xnys_session_too_early, name, strict=True)
+
+    with pytest.raises(
+        errors.NotSessionError,
+        match="is later than the last session of calendar",
+    ):
+        m.parse_session(xnys_cal, xnys_session_too_late, name, strict=True)
+
+
+@pytest.mark.parametrize(
+    "session",
+    [
+        "2021-06-07",
+        pd.Timestamp("2021-06-07"),
+        pd.Timestamp("2021-06-07", tz="UTC"),
+    ],
+)
+def test_parse_session_valid_session_input(xnys_cal, session):
+    parsed_session = m.parse_session(xnys_cal, session)
+    assert isinstance(parsed_session, pd.Timestamp)
+    assert parsed_session.tz.zone == "UTC"
+    assert parsed_session == parsed_session.normalize()
+    assert parsed_session in xnys_cal.schedule.index
+
+
+def test_parse_session_valid_nonsession_input(xnys_cal, xnys_nonsession):
+    parsed_session = m.parse_session(xnys_cal, xnys_nonsession, strict=False)
+    assert isinstance(parsed_session, pd.Timestamp)
+    assert parsed_session.tz.zone == "UTC"
+    assert parsed_session == parsed_session.normalize()
+    assert parsed_session not in xnys_cal.schedule.index

--- a/tests/test_xhkg_calendar.py
+++ b/tests/test_xhkg_calendar.py
@@ -15,6 +15,8 @@ class XHKGCalendarTestCase(ExchangeCalendarTestBase, TestCase):
     answer_key_filename = "xhkg"
     calendar_class = XHKGExchangeCalendar
 
+    HAVE_BREAKS = True
+
     MAX_SESSION_HOURS = 6.5
 
     # Asia/Hong_Kong does not have daylight savings

--- a/tests/test_xses_calendar.py
+++ b/tests/test_xses_calendar.py
@@ -35,7 +35,7 @@ class XSESCalendarTestCase(ExchangeCalendarTestBase, TestCase):
             self.assertNotIn(session_label, self.calendar.all_sessions)
 
     def test_constrain_construction_dates(self):
-        # the XSES calendar currently goes from 1999 to 2025, inclusive.
+        # the XSES calendar currently goes from 1999 to 2021, inclusive.
         with self.assertRaises(ValueError) as e:
             self.calendar_class(T("1985-12-31"), T("2005-01-01"))
 
@@ -48,12 +48,12 @@ class XSESCalendarTestCase(ExchangeCalendarTestBase, TestCase):
         )
 
         with self.assertRaises(ValueError) as e:
-            self.calendar_class(T("2005-01-01"), T("2021-01-01"))
+            self.calendar_class(T("2005-01-01"), T("2022-01-03"))
 
         self.assertEqual(
             str(e.exception),
             (
-                "The XSES holidays are only recorded to 2020,"
-                " cannot instantiate the XSES calendar for 2021."
+                "The XSES holidays are only recorded to 2021,"
+                " cannot instantiate the XSES calendar for 2022."
             ),
         )


### PR DESCRIPTION
References:
https://www.sgx.com/securities/trading#Trading%20Hours%20&%20Opening/Closing%20Routine
https://www.mom.gov.sg/employment-practices/public-holidays

@gerrymanoim, sorry, I've pushed this on top of PR #29. If you want to merge this but not #29 let me know and I'll endeavour to get this on a separate branch.