### PR TITLE
Fix XBOG FutureWarning

### DIFF
--- a/exchange_calendars/common_holidays.py
+++ b/exchange_calendars/common_holidays.py
@@ -17,25 +17,39 @@ def new_years_day(start_date=None, end_date=None, observance=None, days_of_week=
     )
 
 
-def new_years_eve(start_date=None, end_date=None, observance=None, days_of_week=None):
+def new_years_eve(
+    start_date=None,
+    end_date=None,
+    observance=None,
+    days_of_week=None,
+    offset=None,
+):
     return Holiday(
         "New Year's Eve",
         month=12,
         day=31,
         start_date=start_date,
         end_date=end_date,
+        offset=offset,
         observance=observance,
         days_of_week=days_of_week,
     )
 
 
-def epiphany(start_date=None, end_date=None, observance=None, days_of_week=None):
+def epiphany(
+    start_date=None,
+    end_date=None,
+    observance=None,
+    days_of_week=None,
+    offset=None,
+):
     return Holiday(
         "Epiphany",
         month=1,
         day=6,
         start_date=start_date,
         end_date=end_date,
+        offset=offset,
         observance=observance,
         days_of_week=days_of_week,
     )

--- a/exchange_calendars/exchange_calendar_cmes.py
+++ b/exchange_calendars/exchange_calendar_cmes.py
@@ -53,7 +53,7 @@ class CMESExchangeCalendar(ExchangeCalendar):
     - Christmas
     """
 
-    name = "CME"
+    name = "CMES"
 
     tz = timezone("America/Chicago")
 

--- a/exchange_calendars/exchange_calendar_xbog.py
+++ b/exchange_calendars/exchange_calendar_xbog.py
@@ -42,7 +42,7 @@ next_monday_offset = DateOffset(weekday=MO(1))
 
 NewYearsDay = new_years_day()
 
-Epiphany = epiphany(observance=next_monday_offset)
+Epiphany = epiphany(offset=next_monday_offset)
 
 StJosephsDay = Holiday(
     "St. Joseph's Day (next Monday)",
@@ -117,7 +117,7 @@ CartagenaIndependenceDay = Holiday(
     "Cartagena Independence Day",
     month=11,
     day=11,
-    observance=next_monday_offset,
+    offset=next_monday_offset,
 )
 
 ImmaculateConception = immaculate_conception()


### PR DESCRIPTION
Fixes FutureWarning when instantiating `XBOGExchangeCalendar`:  
* ``FutureWarning: DateOffset.__call__ is deprecated and will be removed in a future version.  Use `offset + other` instead.``

Changes CMESExchangeCalendar name from alias name "CME" to canonical name "CMES".