### PR TITLE
Update/add dispatcher alias methods

### DIFF
--- a/exchange_calendars/__init__.py
+++ b/exchange_calendars/__init__.py
@@ -22,6 +22,8 @@ from .calendar_utils import (
     register_calendar_alias,
     register_calendar_type,
     resolve_alias,
+    names_to_aliases,
+    aliases_to_names,
 )
 from .exchange_calendar import ExchangeCalendar
 
@@ -34,6 +36,8 @@ __all__ = [
     "register_calendar_alias",
     "register_calendar_type",
     "resolve_alias",
+    "names_to_aliases",
+    "aliases_to_names",
     "ExchangeCalendar",
 ]
 

--- a/exchange_calendars/calendar_utils.py
+++ b/exchange_calendars/calendar_utils.py
@@ -1,4 +1,4 @@
-import itertools
+from __future__ import annotations
 
 from .always_open import AlwaysOpenCalendar
 from .errors import CalendarNameCollision, CyclicCalendarAlias, InvalidCalendarName
@@ -196,24 +196,32 @@ class ExchangeCalendarDispatcher(object):
         calendar = self._calendars[canonical_name] = factory()
         return calendar
 
-    def get_calendar_names(self):
-        """
-        Returns all the calendars we know about or know how to make
+    def get_calendar_names(self, include_aliases: bool = True) -> list[str]:
+        """Return all canoncial calendar names and, optionally, aliases.
+
+        Parameters
+        ----------
+        include_aliases : default: True
+            True to include calendar aliases.
+            False to return only canonical calendar names.
 
         Returns
         -------
-        calendar_names: List[str]
-            A list of all the calendars we know about or know how to make
+        list of str
+            List of canonical calendar names and, optionally, aliases.
+
+        See Also
+        --------
+        names_to_aliases : Mapping of cononcial names to aliases.
+        aliases_to_names : Mapping of aliases to canoncial names.
+        resolve_alias : Resolve single alias to a canonical name.
         """
-        return list(
-            set(
-                itertools.chain(
-                    self._calendars.keys(),
-                    self._calendar_factories.keys(),
-                    self._aliases.keys(),
-                )
-            )
-        )
+        keys = set(self._calendar_factories.keys()).union(set(self._calendars.keys()))
+        if include_aliases:
+            keys = keys.union(set(self._aliases.keys()))
+        names = list(keys)
+        names.sort()
+        return names
 
     def has_calendar(self, name):
         """
@@ -322,19 +330,25 @@ class ExchangeCalendarDispatcher(object):
             del self._aliases[alias]
             raise
 
-    def resolve_alias(self, name):
-        """
-        Resolve a calendar alias for retrieval.
+    def resolve_alias(self, name: str):
+        """Resolve an alias to cononcial name of corresponding calendar.
+
+        A cononical name will resolve to itself.
 
         Parameters
         ----------
-        name : str
-            The name of the requested calendar.
+        name :
+            Alias or canoncial name corresponding to a calendar.
 
         Returns
         -------
         canonical_name : str
-            The real name of the calendar to create/return.
+            Canonical name of calendar that would be created for `name`.
+
+        See Also
+        --------
+        aliases_to_names : Mapping of aliases to canoncial names.
+        names_to_aliases : Mapping of cononcial names to aliases.
         """
         seen = []
 
@@ -350,13 +364,48 @@ class ExchangeCalendarDispatcher(object):
 
         return name
 
+    def aliases_to_names(self) -> dict[str, str]:
+        """Return dictionary mapping aliases to canonical names.
+
+        Returns
+        -------
+        dict of {str, str}
+            Dictionary mapping aliases to canoncial name of corresponding
+            calendar.
+
+        See Also
+        --------
+        resolve_alias : Resolve single alias to a canonical name.
+        names_to_aliases : Mapping of cononcial names to aliases.
+        """
+        return {alias: self.resolve_alias(alias) for alias in self._aliases}
+
+    def names_to_aliases(self) -> dict[str, list[str]]:
+        """Return mapping of canonical calendar names to associated aliases.
+
+        Returns
+        -------
+        dict of {str, list of str}
+            Dictionary mapping canonical calendar names to any associated
+            aliases.
+
+        See Also
+        --------
+        aliases_to_names : Mapping of aliases to canoncial names.
+        """
+        names = self.get_calendar_names(include_aliases=False)
+        dic = {name: [] for name in names}
+        for alias, name in self.aliases_to_names().items():
+            dic[name].append(alias)
+        return dic
+
     def deregister_calendar(self, name):
         """
         If a calendar is registered with the given name, it is de-registered.
 
         Parameters
         ----------
-        cal_name : str
+        name : str
             The name of the calendar to be deregistered.
         """
         self._calendars.pop(name, None)
@@ -389,3 +438,5 @@ register_calendar = global_calendar_dispatcher.register_calendar
 register_calendar_type = global_calendar_dispatcher.register_calendar_type
 register_calendar_alias = global_calendar_dispatcher.register_calendar_alias
 resolve_alias = global_calendar_dispatcher.resolve_alias
+aliases_to_names = global_calendar_dispatcher.aliases_to_names
+names_to_aliases = global_calendar_dispatcher.names_to_aliases

--- a/exchange_calendars/calendar_utils.py
+++ b/exchange_calendars/calendar_utils.py
@@ -196,7 +196,9 @@ class ExchangeCalendarDispatcher(object):
         calendar = self._calendars[canonical_name] = factory()
         return calendar
 
-    def get_calendar_names(self, include_aliases: bool = True) -> list[str]:
+    def get_calendar_names(
+        self, include_aliases: bool = True, sort: bool = True
+    ) -> list[str]:
         """Return all canoncial calendar names and, optionally, aliases.
 
         Parameters
@@ -204,6 +206,9 @@ class ExchangeCalendarDispatcher(object):
         include_aliases : default: True
             True to include calendar aliases.
             False to return only canonical calendar names.
+
+        sort : default: True
+            Return calendar names sorted alphabetically.
 
         Returns
         -------
@@ -220,7 +225,8 @@ class ExchangeCalendarDispatcher(object):
         if include_aliases:
             keys = keys.union(set(self._aliases.keys()))
         names = list(keys)
-        names.sort()
+        if sort:
+            names.sort()
         return names
 
     def has_calendar(self, name):
@@ -356,7 +362,7 @@ class ExchangeCalendarDispatcher(object):
         aliases_to_names : Mapping of aliases to canoncial names.
         names_to_aliases : Mapping of cononcial names to aliases.
         """
-        if name not in self.get_calendar_names(include_aliases=True):
+        if name not in self.get_calendar_names(include_aliases=True, sort=False):
             raise InvalidCalendarName(calendar_name=name)
 
         seen = []

--- a/exchange_calendars/calendar_utils.py
+++ b/exchange_calendars/calendar_utils.py
@@ -345,11 +345,20 @@ class ExchangeCalendarDispatcher(object):
         canonical_name : str
             Canonical name of calendar that would be created for `name`.
 
+        Raises
+        ------
+        InvalidCalendarName
+            If `name` is not an alias or canonical name of any registered
+            calendar.
+
         See Also
         --------
         aliases_to_names : Mapping of aliases to canoncial names.
         names_to_aliases : Mapping of cononcial names to aliases.
         """
+        if name not in self.get_calendar_names(include_aliases=True):
+            raise InvalidCalendarName(calendar_name=name)
+
         seen = []
 
         while name in self._aliases:

--- a/exchange_calendars/exchange_calendar_xses.py
+++ b/exchange_calendars/exchange_calendar_xses.py
@@ -376,7 +376,7 @@ class XSESExchangeCalendar(PrecomputedExchangeCalendar):
     NOTE: For now, we are skipping the intra-day break from 12:00 to 13:00.
 
     Due to the complexity around the Singaporean holidays, we are hardcoding
-    a list of holidays covering 1986-2020, inclusive.
+    a list of holidays covering 1986-2021, inclusive.
 
     TODO: There are a handful of half-days (day before Chinese New Year,
     Christmas Eve, etc.). We will add those later.

--- a/tests/test_calendar_dispatcher.py
+++ b/tests/test_calendar_dispatcher.py
@@ -103,3 +103,22 @@ class CalendarAliasTestCase(TestCase):
             sorted(self.dispatcher.get_calendar_names()),
             ["IEPA", "IEPA_ALIAS", "IEPA_ALIAS_ALIAS"],
         )
+        self.assertEqual(
+            self.dispatcher.get_calendar_names(include_aliases=False),
+            ["IEPA"],
+        )
+
+    def test_aliases_to_names(self):
+        self.assertDictEqual(
+            self.dispatcher.aliases_to_names(),
+            {
+                "IEPA_ALIAS": "IEPA",
+                "IEPA_ALIAS_ALIAS": "IEPA",
+            },
+        )
+
+    def test_names_to_aliases(self):
+        self.assertDictEqual(
+            self.dispatcher.names_to_aliases(),
+            {"IEPA": ["IEPA_ALIAS", "IEPA_ALIAS_ALIAS"]},
+        )


### PR DESCRIPTION
Updates and adds `ExchangeCalendarDispatcher` methods to provide increased visibility of relationships between aliases and canonical names.

* Introduces `include_aliases` parameter (default: True) to `get_calendar_names`.
* EDIT: `resolve_alias` raises `InvalidCalendarName` if receives `name` that is not an alias or canonical name of a registered calendar.

* New methods:
    * `aliases_to_names` returns mapping of aliases to canonical names.
    * `names_to_aliases` returns mapping of canonical names to any aliases.

~~To add context, introduces new `get_exchanges_info` function to `calendar_utils`. NB requires new dependency `lxml`. @gerrymanoim, I've included this under its own commit, if you don't feel it's worth the extra dependency I can exclude it.~~
