### PR TITLE
Expose calendar kwargs via get_calendar and handle out-of-bounds dates

### DIFF
--- a/exchange_calendars/__init__.py
+++ b/exchange_calendars/__init__.py
@@ -22,6 +22,8 @@ from .calendar_utils import (
     register_calendar_alias,
     register_calendar_type,
     resolve_alias,
+    names_to_aliases,
+    aliases_to_names,
 )
 from .exchange_calendar import ExchangeCalendar
 
@@ -34,6 +36,8 @@ __all__ = [
     "register_calendar_alias",
     "register_calendar_type",
     "resolve_alias",
+    "names_to_aliases",
+    "aliases_to_names",
     "ExchangeCalendar",
 ]
 

--- a/exchange_calendars/calendar_utils.py
+++ b/exchange_calendars/calendar_utils.py
@@ -1,4 +1,4 @@
-import itertools
+from __future__ import annotations
 
 from .always_open import AlwaysOpenCalendar
 from .errors import CalendarNameCollision, CyclicCalendarAlias, InvalidCalendarName
@@ -196,24 +196,32 @@ class ExchangeCalendarDispatcher(object):
         calendar = self._calendars[canonical_name] = factory()
         return calendar
 
-    def get_calendar_names(self):
-        """
-        Returns all the calendars we know about or know how to make
+    def get_calendar_names(self, include_aliases: bool = True) -> list[str]:
+        """Return all canoncial calendar names and, optionally, aliases.
+
+        Parameters
+        ----------
+        include_aliases : default: True
+            True to include calendar aliases.
+            False to return only canonical calendar names.
 
         Returns
         -------
-        calendar_names: List[str]
-            A list of all the calendars we know about or know how to make
+        list of str
+            List of canonical calendar names and, optionally, aliases.
+
+        See Also
+        --------
+        names_to_aliases : Mapping of cononcial names to aliases.
+        aliases_to_names : Mapping of aliases to canoncial names.
+        resolve_alias : Resolve single alias to a canonical name.
         """
-        return list(
-            set(
-                itertools.chain(
-                    self._calendars.keys(),
-                    self._calendar_factories.keys(),
-                    self._aliases.keys(),
-                )
-            )
-        )
+        keys = set(self._calendar_factories.keys()).union(set(self._calendars.keys()))
+        if include_aliases:
+            keys = keys.union(set(self._aliases.keys()))
+        names = list(keys)
+        names.sort()
+        return names
 
     def has_calendar(self, name):
         """
@@ -322,19 +330,25 @@ class ExchangeCalendarDispatcher(object):
             del self._aliases[alias]
             raise
 
-    def resolve_alias(self, name):
-        """
-        Resolve a calendar alias for retrieval.
+    def resolve_alias(self, name: str):
+        """Resolve an alias to cononcial name of corresponding calendar.
+
+        A cononical name will resolve to itself.
 
         Parameters
         ----------
-        name : str
-            The name of the requested calendar.
+        name :
+            Alias or canoncial name corresponding to a calendar.
 
         Returns
         -------
         canonical_name : str
-            The real name of the calendar to create/return.
+            Canonical name of calendar that would be created for `name`.
+
+        See Also
+        --------
+        aliases_to_names : Mapping of aliases to canoncial names.
+        names_to_aliases : Mapping of cononcial names to aliases.
         """
         seen = []
 
@@ -350,13 +364,48 @@ class ExchangeCalendarDispatcher(object):
 
         return name
 
+    def aliases_to_names(self) -> dict[str, str]:
+        """Return dictionary mapping aliases to canonical names.
+
+        Returns
+        -------
+        dict of {str, str}
+            Dictionary mapping aliases to canoncial name of corresponding
+            calendar.
+
+        See Also
+        --------
+        resolve_alias : Resolve single alias to a canonical name.
+        names_to_aliases : Mapping of cononcial names to aliases.
+        """
+        return {alias: self.resolve_alias(alias) for alias in self._aliases}
+
+    def names_to_aliases(self) -> dict[str, list[str]]:
+        """Return mapping of canonical calendar names to associated aliases.
+
+        Returns
+        -------
+        dict of {str, list of str}
+            Dictionary mapping canonical calendar names to any associated
+            aliases.
+
+        See Also
+        --------
+        aliases_to_names : Mapping of aliases to canoncial names.
+        """
+        names = self.get_calendar_names(include_aliases=False)
+        dic = {name: [] for name in names}
+        for alias, name in self.aliases_to_names().items():
+            dic[name].append(alias)
+        return dic
+
     def deregister_calendar(self, name):
         """
         If a calendar is registered with the given name, it is de-registered.
 
         Parameters
         ----------
-        cal_name : str
+        name : str
             The name of the calendar to be deregistered.
         """
         self._calendars.pop(name, None)
@@ -389,3 +438,5 @@ register_calendar = global_calendar_dispatcher.register_calendar
 register_calendar_type = global_calendar_dispatcher.register_calendar_type
 register_calendar_alias = global_calendar_dispatcher.register_calendar_alias
 resolve_alias = global_calendar_dispatcher.resolve_alias
+aliases_to_names = global_calendar_dispatcher.aliases_to_names
+names_to_aliases = global_calendar_dispatcher.names_to_aliases

--- a/exchange_calendars/calendar_utils.py
+++ b/exchange_calendars/calendar_utils.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+from .calendar_helpers import parse_session
 from .always_open import AlwaysOpenCalendar
 from .errors import CalendarNameCollision, CyclicCalendarAlias, InvalidCalendarName
+from .exchange_calendar import ExchangeCalendar
 from .exchange_calendar_asex import ASEXExchangeCalendar
 from .exchange_calendar_bvmf import BVMFExchangeCalendar
 from .exchange_calendar_cmes import CMESExchangeCalendar
@@ -146,8 +148,8 @@ class ExchangeCalendarDispatcher(object):
     """
     A class for dispatching and caching exchange calendars.
 
-    Methods of a global instance of this class are provided by
-    calendars.calendar_utils.
+    Methods of a global instance of this class can be accessed directly
+    from exchange_calendars, for example `exchange_calendars.get_calendar`.
 
     Parameters
     ----------
@@ -163,38 +165,90 @@ class ExchangeCalendarDispatcher(object):
         self._calendars = calendars
         self._calendar_factories = dict(calendar_factories)
         self._aliases = dict(aliases)
+        # key: factory name, value: (calendar, dict of calendar kwargs)
+        self._factory_output_cache: dict(str, tuple(ExchangeCalendar, dict)) = {}
 
-    def get_calendar(self, name):
+    def _fabricate(self, name: str, **kwargs) -> ExchangeCalendar:
+        """Fabricate calendar with `name` and `**kwargs`."""
+        try:
+            factory = self._calendar_factories[name]
+        except KeyError as e:
+            raise InvalidCalendarName(calendar_name=name) from e
+        calendar = factory(**kwargs)
+        self._factory_output_cache[name] = (calendar, kwargs)
+        return calendar
+
+    def _get_cached_factory_output(
+        self, name: str, **kwargs
+    ) -> ExchangeCalendar | None:
+        """Get calendar from factory output cache.
+
+        Return None if `name` not in cache or `name` in cache although
+        calendar got with kwargs other than `**kwargs`.
         """
-        Retrieves an instance of an ExchangeCalendar whose name is given.
+        calendar, calendar_kwargs = self._factory_output_cache.get(name, (None, None))
+        if calendar is not None and calendar_kwargs == kwargs:
+            return calendar
+        else:
+            return None
+
+    def get_calendar(self, name: str, **kwargs) -> ExchangeCalendar:
+        """Get exchange calendar with a given name.
 
         Parameters
         ----------
-        name : str
-            The name of the ExchangeCalendar to be retrieved.
+        name
+            Name of the ExchangeCalendar to get, for example 'XNYS'.
+
+        **kwargs
+            Kwargs to be passed to calendar factory. `**kwargs` can only be
+            passed if `name` is registered as a calendar factory (either by
+            having being included to `calendar_factories` passed to the
+            dispatcher's constructor or having been subsequently registered
+            via the `register_calendar_type` method).
 
         Returns
         -------
-        calendar : calendars.ExchangeCalendar
-            The desired calendar.
+        ExchangeCalendar
+            Requested calendar.
+
+        Raises
+        ------
+        InvalidCalendarName
+            If `name` does not represent a registered calendar.
+
+        ValueError
+            If `**kwargs` are received although `name` is a registered
+            calendar (as opposed to a calendar factory).
+
+            If `start` or `end` are included to `**kwargs` although do not
+            parse as a date that could represent a session.
         """
-        canonical_name = self.resolve_alias(name)
+        # will raise InvalidCalendarName if name not valid
+        name = self.resolve_alias(name)
 
-        try:
-            return self._calendars[canonical_name]
-        except KeyError:
-            # We haven't loaded this calendar yet, so make a new one.
-            pass
+        if name in self._calendars:
+            if kwargs:
+                raise ValueError(
+                    f"Receieved constructor arguments `start` and/or `end`"
+                    f" although calendar {name} is registered as a specific"
+                    f" instance of class {self._calendars[name].__class__},"
+                    f" not as a calendar factory."
+                )
+            else:
+                return self._calendars[name]
 
-        try:
-            factory = self._calendar_factories[canonical_name]
-        except KeyError:
-            # We don't have a factory registered for this name.  Barf.
-            raise InvalidCalendarName(calendar_name=name)
+        if kwargs.get("start"):
+            kwargs["start"] = parse_session(kwargs["start"], "start", strict=None)
+        else:
+            kwargs["start"] = None
+        if kwargs.get("end"):
+            kwargs["end"] = parse_session(kwargs["end"], "end", strict=None)
+        else:
+            kwargs["end"] = None
 
-        # Cache the calendar for future use.
-        calendar = self._calendars[canonical_name] = factory()
-        return calendar
+        cached = self._get_cached_factory_output(name, **kwargs)
+        return cached if cached is not None else self._fabricate(name, **kwargs)
 
     def get_calendar_names(self, include_aliases: bool = True) -> list[str]:
         """Return all canoncial calendar names and, optionally, aliases.

--- a/exchange_calendars/calendar_utils.py
+++ b/exchange_calendars/calendar_utils.py
@@ -345,11 +345,20 @@ class ExchangeCalendarDispatcher(object):
         canonical_name : str
             Canonical name of calendar that would be created for `name`.
 
+        Raises
+        ------
+        InvalidCalendarName
+            If `name` is not an alias or canonical name of any registered
+            calendar.
+
         See Also
         --------
         aliases_to_names : Mapping of aliases to canoncial names.
         names_to_aliases : Mapping of cononcial names to aliases.
         """
+        if name not in self.get_calendar_names(include_aliases=True):
+            raise InvalidCalendarName(calendar_name=name)
+
         seen = []
 
         while name in self._aliases:

--- a/exchange_calendars/exchange_calendar.py
+++ b/exchange_calendars/exchange_calendar.py
@@ -37,11 +37,10 @@ from .utils.memoize import lazyval
 from .utils.pandas_utils import days_at_time
 from .pandas_extensions.offsets import MultipleWeekmaskCustomBusinessDay
 
-start_default = pd.Timestamp("1990-01-01", tz=UTC)
-end_base = pd.Timestamp("today", tz=UTC)
+GLOBAL_DEFAULT_START = pd.Timestamp.now(tz=UTC).floor("D") - pd.DateOffset(years=20)
 # Give an aggressive buffer for logic that needs to use the next trading
 # day or minute.
-end_default = end_base + pd.Timedelta(days=365)
+GLOBAL_DEFAULT_END = pd.Timestamp.now(tz=UTC).floor("D") + pd.DateOffset(years=1)
 
 NANOS_IN_MINUTE = 60000000000
 MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY = range(7)
@@ -75,23 +74,88 @@ def _group_times(all_days, times, tz, offset=0):
 
 
 class ExchangeCalendar(ABC):
+    """Representation of timing information of a single market exchange.
+
+    The timing information is made up of two parts: sessions, and
+    opens/closes (and break_starts/break_ends for exchanges that observe
+    an intraday break).
+
+    For exchanges that do not observe an intraday break a session
+    represents a contiguous set of minutes. Where an exchange observes
+    an intraday break a session represents two contiguous set of minutes
+    separated by the intraday break.
+
+    Each session has a label that is midnight UTC. It is important to note
+    that a session label should not be considered a specific point in time,
+    and that midnight UTC is just being used for convenience.
+
+    For each session, we store the open and close time together with, for
+    those exchanges with breaks, the break start and break end. All times
+    are defined as UTC.
+
+    Parameters
+    ----------
+    start : default: later of 20 years ago or first supported start date.
+        First calendar session will be `start`, if `start` is a session, or
+        first session after `start`.
+
+    end : default: earliest of 1 year from 'today' or last supported end date.
+        Last calendar session will be `end`, if `end` is a session, or last
+        session before `end`.
+
+    Raises
+    ------
+    ValueError
+        If `start` is earlier than the earliest supported start date.
+        If `end` is later than the latest supported end date.
+        If `start` parses to a later date than `end`.
+
+    Notes
+    -----
+    Exchange calendars were originally defined for the Zipline package from
+    Quantopian under the package 'trading_calendars'. Since 2021 they have
+    been maintained under the 'exchange_calendars' package (a fork of
+    'trading_calendars') by an active community of contributing users.
+
+    Some calendars have defined start and end bounds within which
+    contributors have endeavoured to ensure the calendar's accuracy and
+    outside of which the calendar would not be accurate. These bounds
+    are enforced such that passing `start` or `end` as dates that are
+    out-of-bounds will raise a ValueError. The bounds of each calendar are
+    exposed via the `bound_start` and `bound_end` properties.
+
+    Many calendars do not have bounds defined (`bound_start` and/or
+    `bound_end` return None). These calendars can be created through any
+    date range although it should be noted that the further back the
+    start date, the greater the potential for inaccuracies.
+
+    In all cases, no guarantees are offered as to the accuracy of any
+    calendar.
     """
-    An ExchangeCalendar represents the timing information of a single market
-    exchange.
 
-    The timing information is made up of two parts: sessions, and opens/closes.
+    def __init__(self, start: Session | None = None, end: Session | None = None):
 
-    A session represents a contiguous set of minutes, and has a label that is
-    midnight UTC. It is important to note that a session label should not be
-    considered a specific point in time, and that midnight UTC is just being
-    used for convenience.
+        if start is None:
+            start = self._default_start
+        else:
+            start = parse_session(start, "start", strict=False)
+            if self.bound_start is not None and start < self.bound_start:
+                raise ValueError(self._bound_start_error_msg(start))
 
-    For each session, we store the open and close time in UTC time.
-    """
+        if end is None:
+            end = self._default_end
+        else:
+            end = parse_session(end, "end", strict=False)
+            if self.bound_end is not None and end > self.bound_end:
+                raise ValueError(self._bound_end_error_msg(end))
 
-    def __init__(self, start=start_default, end=end_default):
+        if start >= end:
+            raise ValueError(
+                "`start` must be earlier than `end` although `start` parsed as"
+                f" '{start}' and `end` as '{end}'."
+            )
+
         # Midnight in UTC for each trading day.
-
         _all_days = date_range(start, end, freq=self.day, tz=UTC)
 
         # `DatetimeIndex`s of standard opens/closes for each day.
@@ -183,6 +247,81 @@ class ExchangeCalendar(ABC):
         self._early_closes = pd.DatetimeIndex(
             _special_closes.map(self.minute_index_to_session_labels)
         )
+
+    @property
+    def bound_start(self) -> pd.Timestamp | None:
+        """Earliest date from which calendar can be constructed.
+
+        Returns
+        -------
+        pd.Timestamp or None
+            Earliest date from which calendar can be constructed. Must have
+            tz as "UTC". None if no limit.
+
+        Notes
+        -----
+        To impose a constraint on the earliest date from which a calendar
+        can be constructed subclass should override this method and
+        optionally override `_bound_start_error_msg`.
+        """
+        return None
+
+    @property
+    def bound_end(self) -> pd.Timestamp | None:
+        """Latest date to which calendar can be constructed.
+
+        Returns
+        -------
+        pd.Timestamp or None
+            Latest date to which calendar can be constructed. Must have tz
+            as "UTC". None if no limit.
+
+        Notes
+        -----
+        To impose a constraint on the latest date to which a calendar can
+        be constructed subclass should override this method and optionally
+        override `_bound_end_error_msg`.
+        """
+        return None
+
+    def _bound_start_error_msg(self, start: pd.Timestamp) -> str:
+        """Return error message to handle `start` being out-of-bounds.
+
+        See Also
+        --------
+        bound_start
+        """
+        return (
+            f"The earliest date from which calendar {self.name} can be"
+            f" evaluated is {self.bound_start}, although received `start` as"
+            f" {start}."
+        )
+
+    def _bound_end_error_msg(self, end: pd.Timestamp) -> str:
+        """Return error message to handle `end` being out-of-bounds.
+
+        See Also
+        --------
+        bound_end
+        """
+        return (
+            f"The latest date to which calendar {self.name} can be evaluated"
+            f" is {self.bound_end}, although received `end` as {end}."
+        )
+
+    @property
+    def _default_start(self) -> pd.Timestamp:
+        if self.bound_start is None:
+            return GLOBAL_DEFAULT_START
+        else:
+            return max(GLOBAL_DEFAULT_START, self.bound_start)
+
+    @property
+    def _default_end(self) -> pd.Timestamp:
+        if self.bound_end is None:
+            return GLOBAL_DEFAULT_END
+        else:
+            return min(GLOBAL_DEFAULT_END, self.bound_end)
 
     @lazyval
     def day(self):
@@ -707,9 +846,7 @@ class ExchangeCalendar(ABC):
             end_minute=self.schedule.at[session_label, "market_close"],
         )
 
-    def execution_minutes_for_session(
-        self, session_label: Session
-    ) -> pd.DatetimeIndex:
+    def execution_minutes_for_session(self, session_label: Session) -> pd.DatetimeIndex:
         """
         Given a session label, return the execution minutes for that session.
 
@@ -783,9 +920,7 @@ class ExchangeCalendar(ABC):
             self.all_sessions.slice_indexer(start_session_label, end_session_label)
         ]
 
-    def sessions_window(
-        self, session_label: Session, count: int
-    ) -> pd.DatetimeIndex:
+    def sessions_window(self, session_label: Session, count: int) -> pd.DatetimeIndex:
         """
         Given a session label and a window size, returns a list of sessions
         of size `count` + 1, that either starts with the given session
@@ -907,9 +1042,7 @@ class ExchangeCalendar(ABC):
         start_session_label = parse_session(
             start_session_label, "start_session_label", self
         )
-        end_session_label = parse_session(
-            end_session_label, "end_session_label", self
-        )
+        end_session_label = parse_session(end_session_label, "end_session_label", self)
         first_minute, _ = self.open_and_close_for_session(start_session_label)
         _, last_minute = self.open_and_close_for_session(end_session_label)
 

--- a/exchange_calendars/exchange_calendar_xhkg.py
+++ b/exchange_calendars/exchange_calendar_xhkg.py
@@ -49,8 +49,8 @@ from .exchange_calendar import (
     TUESDAY,
     WEDNESDAY,
     HolidayCalendar,
-    ExchangeCalendar,
 )
+from .precomputed_exchange_calendar import PrecomputedExchangeCalendar
 from .utils.pandas_utils import vectorized_sunday_to_monday
 
 # Useful resources for making changes to this file:
@@ -232,7 +232,7 @@ def boxing_day_obs(dt):
     return dt
 
 
-class XHKGExchangeCalendar(ExchangeCalendar):
+class XHKGExchangeCalendar(PrecomputedExchangeCalendar):
     """
     Exchange calendar for the Hong Kong Stock Exchange (XHKG).
 
@@ -282,37 +282,6 @@ class XHKGExchangeCalendar(ExchangeCalendar):
         (pd.Timestamp("2011-03-07"), time(12, 00)),
     )
 
-    def __init__(self, *args, **kwargs):
-        super(XHKGExchangeCalendar, self).__init__(*args, **kwargs)
-
-        lunisolar_holidays = (
-            chinese_buddhas_birthday_dates,
-            chinese_lunar_new_year_dates,
-            day_after_mid_autumn_festival_dates,
-            double_ninth_festival_dates,
-            dragon_boat_festival_dates,
-            qingming_festival_dates,
-        )
-        earliest_precomputed_year = max(map(np.min, lunisolar_holidays)).year
-        if earliest_precomputed_year > self.first_trading_session.year:
-            raise ValueError(
-                "the lunisolar holidays have only been computed back to {},"
-                " cannot instantiate the XHKG calendar back to {}".format(
-                    earliest_precomputed_year,
-                    self.first_trading_session.year,
-                ),
-            )
-
-        latest_precomputed_year = min(map(np.max, lunisolar_holidays)).year
-        if latest_precomputed_year < self.last_trading_session.year:
-            raise ValueError(
-                "the lunisolar holidays have only been computed through {},"
-                " cannot instantiate the XHKG calendar in {}".format(
-                    latest_precomputed_year,
-                    self.last_trading_session.year,
-                ),
-            )
-
     @property
     def regular_holidays(self):
         return HolidayCalendar(
@@ -334,7 +303,28 @@ class XHKGExchangeCalendar(ExchangeCalendar):
         )
 
     @property
+    def precomputed_holidays(self):
+        lunisolar_holidays = (
+            chinese_buddhas_birthday_dates,
+            chinese_lunar_new_year_dates,
+            day_after_mid_autumn_festival_dates,
+            double_ninth_festival_dates,
+            dragon_boat_festival_dates,
+            qingming_festival_dates,
+        )
+        return lunisolar_holidays
+
+    @property
+    def _earliest_precomputed_year(self) -> int:
+        return max(map(np.min, self.precomputed_holidays)).year
+
+    @property
+    def _latest_precomputed_year(self) -> int:
+        return min(map(np.max, self.precomputed_holidays)).year
+
+    @property
     def adhoc_holidays(self):
+        # overrides as inherited from PrecomputedExchangeCalendar
         lunar_new_years_eve = (chinese_lunar_new_year_dates - pd.Timedelta(days=1))[
             (chinese_lunar_new_year_dates.weekday == SATURDAY)
             & (chinese_lunar_new_year_dates.year < 2013)

--- a/exchange_calendars/exchange_calendar_xses.py
+++ b/exchange_calendars/exchange_calendar_xses.py
@@ -376,7 +376,7 @@ class XSESExchangeCalendar(PrecomputedExchangeCalendar):
     NOTE: For now, we are skipping the intra-day break from 12:00 to 13:00.
 
     Due to the complexity around the Singaporean holidays, we are hardcoding
-    a list of holidays covering 1986-2020, inclusive.
+    a list of holidays covering 1986-2021, inclusive.
 
     TODO: There are a handful of half-days (day before Chinese New Year,
     Christmas Eve, etc.). We will add those later.

--- a/exchange_calendars/exchange_calendar_xtks.py
+++ b/exchange_calendars/exchange_calendar_xtks.py
@@ -4,7 +4,7 @@ from itertools import chain
 import pandas as pd
 from pytz import UTC, timezone
 
-from .exchange_calendar import HolidayCalendar, ExchangeCalendar, end_default
+from .exchange_calendar import HolidayCalendar, ExchangeCalendar
 from .xtks_holidays import (
     AutumnalEquinoxes,
     ChildrensDay,
@@ -44,8 +44,6 @@ from .xtks_holidays import (
     VernalEquinoxes,
 )
 
-XTKS_START_DEFAULT = pd.Timestamp("2000-01-01", tz=UTC)
-
 
 class XTKSExchangeCalendar(ExchangeCalendar):
     """
@@ -78,11 +76,6 @@ class XTKSExchangeCalendar(ExchangeCalendar):
     - Emperor's Birthday (Dec. 23)
     """
 
-    def __init__(self, start=XTKS_START_DEFAULT, end=end_default):
-        # because we are not tracking holiday info farther back than 2000,
-        # make the default start date 01-01-2000
-        super(XTKSExchangeCalendar, self).__init__(start=start, end=end)
-
     name = "XTKS"
 
     tz = timezone("Asia/Tokyo")
@@ -90,6 +83,11 @@ class XTKSExchangeCalendar(ExchangeCalendar):
     open_times = ((None, time(9)),)
 
     close_times = ((None, time(15)),)
+
+    @property
+    def bound_start(self) -> pd.Timestamp:
+        # not tracking holiday info farther back than 2000
+        return pd.Timestamp("2000-01-01", tz=UTC)
 
     @property
     def regular_holidays(self):

--- a/exchange_calendars/us_futures_calendar.py
+++ b/exchange_calendars/us_futures_calendar.py
@@ -4,8 +4,7 @@ from pandas import Timedelta, Timestamp
 from pandas.tseries.holiday import GoodFriday
 from pytz import UTC, timezone
 
-from .exchange_calendar import ExchangeCalendar
-from exchange_calendars.exchange_calendar import HolidayCalendar, end_default
+from exchange_calendars.exchange_calendar import ExchangeCalendar, HolidayCalendar
 from exchange_calendars.us_holidays import Christmas, USNewYearsDay
 
 # Number of hours of offset between the open and close times dictated by this
@@ -36,18 +35,19 @@ class QuantopianUSFuturesCalendar(ExchangeCalendar):
     CME Pre-Open hour (5-6pm).
     """
 
-    # XXX: Override the default ExchangeCalendar start and end dates with ones
-    # further in the future. This is a stopgap for memory issues caused by
-    # upgrading to pandas 18. This calendar is the most severely affected,
-    # since it has the most total minutes of any of the zipline calendars.
-    def __init__(self, start=Timestamp("2000-01-01", tz=UTC), end=end_default):
-        super(QuantopianUSFuturesCalendar, self).__init__(start=start, end=end)
-
     name = "us_futures"
     tz = timezone("America/New_York")
     open_times = ((None, time(18, 1)),)
     close_times = ((None, time(18)),)
     open_offset = -1
+
+    @property
+    def _default_start(self) -> Timestamp:
+        # XXX: Override the default start date. This is a stopgap for memory
+        # issues caused by upgrading to pandas 18. This calendar is the most
+        # severely affected since it has the most total minutes of any of the
+        # zipline calendars.
+        return Timestamp("2000-01-01", tz=UTC)
 
     def execution_time_from_open(self, open_dates):
         return open_dates + Timedelta(hours=FUTURES_OPEN_TIME_OFFSET)

--- a/tests/test_always_open.py
+++ b/tests/test_always_open.py
@@ -18,6 +18,7 @@ class AlwaysOpenTestCase(ExchangeCalendarTestBase, TestCase):
     MAX_SESSION_HOURS = 24
     GAPS_BETWEEN_SESSIONS = False
     HAVE_EARLY_CLOSES = False
+    SESSION_WITHOUT_BREAK = pd.Timestamp("2016-06-15", tz="UTC")
 
     MINUTE_INDEX_TO_SESSION_LABELS_START = pd.Timestamp("2016-01-01", tz=UTC)
     MINUTE_INDEX_TO_SESSION_LABELS_END = pd.Timestamp("2016-04-04", tz=UTC)

--- a/tests/test_calendar_dispatcher.py
+++ b/tests/test_calendar_dispatcher.py
@@ -103,3 +103,22 @@ class CalendarAliasTestCase(TestCase):
             sorted(self.dispatcher.get_calendar_names()),
             ["IEPA", "IEPA_ALIAS", "IEPA_ALIAS_ALIAS"],
         )
+        self.assertEqual(
+            self.dispatcher.get_calendar_names(include_aliases=False),
+            ["IEPA"],
+        )
+
+    def test_aliases_to_names(self):
+        self.assertDictEqual(
+            self.dispatcher.aliases_to_names(),
+            {
+                "IEPA_ALIAS": "IEPA",
+                "IEPA_ALIAS_ALIAS": "IEPA",
+            },
+        )
+
+    def test_names_to_aliases(self):
+        self.assertDictEqual(
+            self.dispatcher.names_to_aliases(),
+            {"IEPA": ["IEPA_ALIAS", "IEPA_ALIAS_ALIAS"]},
+        )

--- a/tests/test_calendar_dispatcher.py
+++ b/tests/test_calendar_dispatcher.py
@@ -3,23 +3,24 @@ Tests for ExchangeCalendarDispatcher.
 """
 from unittest import TestCase
 
+import pandas as pd
+
+from exchange_calendars import ExchangeCalendar
 from exchange_calendars.calendar_utils import ExchangeCalendarDispatcher
+from exchange_calendars.exchange_calendar_iepa import IEPAExchangeCalendar
 from exchange_calendars.errors import (
     CalendarNameCollision,
     CyclicCalendarAlias,
     InvalidCalendarName,
 )
-from exchange_calendars.exchange_calendar_iepa import IEPAExchangeCalendar
 
 
-class CalendarAliasTestCase(TestCase):
+class CalendarDispatcherTestCase(TestCase):
     @classmethod
     def setup_class(cls):
-        # Make a calendar once so that we don't spend time in every test
-        # instantiating calendars.
         cls.dispatcher_kwargs = dict(
-            calendars={"IEPA": IEPAExchangeCalendar()},
-            calendar_factories={},
+            calendars={},
+            calendar_factories={"IEPA": IEPAExchangeCalendar},
             aliases={
                 "IEPA_ALIAS": "IEPA",
                 "IEPA_ALIAS_ALIAS": "IEPA_ALIAS",
@@ -122,3 +123,29 @@ class CalendarAliasTestCase(TestCase):
             self.dispatcher.names_to_aliases(),
             {"IEPA": ["IEPA_ALIAS", "IEPA_ALIAS_ALIAS"]},
         )
+
+    def test_get_calendar(self):
+        cal = self.dispatcher.get_calendar("IEPA")
+        self.assertIsInstance(cal, ExchangeCalendar)
+
+    def test_get_calendar_kwargs(self):
+        start = pd.Timestamp("2020-01-02", tz="UTC")
+        end = pd.Timestamp("2020-01-31", tz="UTC")
+        cal = self.dispatcher.get_calendar("IEPA", start=start, end=end)
+        self.assertEqual(cal.first_session, start)
+        self.assertEqual(cal.last_session, end)
+
+        self.dispatcher.register_calendar("iepa_instance", cal)
+        with self.assertRaises(ValueError):
+            # Can only pass kwargs to registered factories (not calendar instances)
+            self.dispatcher.get_calendar("iepa_instance", start=start)
+
+    def test_get_calendar_cache(self):
+        start = pd.Timestamp("2020-01-02", tz="UTC")
+        end = pd.Timestamp("2020-01-31", tz="UTC")
+        cal = self.dispatcher.get_calendar("IEPA", start=start, end=end)
+        cal2 = self.dispatcher.get_calendar("IEPA", start=start, end=end)
+        self.assertIs(cal, cal2)
+        start += pd.DateOffset(days=1)
+        cal3 = self.dispatcher.get_calendar("IEPA", start=start, end=end)
+        self.assertIsNot(cal, cal3)

--- a/tests/test_exchange_calendar.py
+++ b/tests/test_exchange_calendar.py
@@ -12,11 +12,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
 from datetime import time
 from os.path import abspath, dirname, join
 from unittest import TestCase
 
-import pytest
 import numpy as np
 import pandas as pd
 import pandas.testing as tm
@@ -33,6 +33,7 @@ from exchange_calendars.calendar_utils import (
 )
 from exchange_calendars.errors import CalendarNameCollision, InvalidCalendarName
 from exchange_calendars.exchange_calendar import ExchangeCalendar, days_at_time
+from .test_utils import T
 
 
 class FakeCalendar(ExchangeCalendar):
@@ -169,6 +170,13 @@ class ExchangeCalendarTestBase(object):
     answer_key_filename = None
     calendar_class = None
 
+    # Affects test_start_bound. Should be set to earliest date for which
+    # calendar can be instantiated, or None if no start bound.
+    START_BOUND: pd.Timestamp | None = None
+    # Affects test_end_bound. Should be set to latest date for which
+    # calendar can be instantiated, or None if no end bound.
+    END_BOUND: pd.Timestamp | None = None
+
     # Affects tests that care about the empty periods between sessions. Should
     # be set to False for 24/7 calendars.
     GAPS_BETWEEN_SESSIONS = True
@@ -184,6 +192,10 @@ class ExchangeCalendarTestBase(object):
     # Affects test_for_breaks. True if one or more calendar sessions has a
     # break.
     HAVE_BREAKS = False
+
+    # Affects test_session_has_break.
+    SESSION_WITH_BREAK = None  # None if no session has a break
+    SESSION_WITHOUT_BREAK = T("2011-06-15")  # None if all sessions have breaks
 
     # Affects test_sanity_check_session_lengths. Should be set to the largest
     # number of hours that ever appear in a single session.
@@ -237,11 +249,36 @@ class ExchangeCalendarTestBase(object):
 
         cls.one_minute = pd.Timedelta(minutes=1)
         cls.one_hour = pd.Timedelta(hours=1)
+        cls.today = pd.Timestamp.now(tz="UTC").floor("D")
 
     @classmethod
     def teardown_class(cls):
         cls.calendar = None
         cls.answers = None
+
+    def test_start_bound(self):
+        if self.START_BOUND is not None:
+            cal = self.calendar_class(self.START_BOUND, self.today)
+            self.assertIsInstance(cal, ExchangeCalendar)
+            with self.assertRaises(ValueError):
+                self.calendar_class(
+                    self.START_BOUND - pd.DateOffset(days=1), self.today
+                )
+        else:
+            # verify no bound imposed
+            cal = self.calendar_class(pd.Timestamp("1902-01-01", tz="UTC"), self.today)
+            self.assertIsInstance(cal, ExchangeCalendar)
+
+    def test_end_bound(self):
+        if self.END_BOUND is not None:
+            cal = self.calendar_class(self.today, self.END_BOUND)
+            self.assertIsInstance(cal, ExchangeCalendar)
+            with self.assertRaises(ValueError):
+                self.calendar_class(self.today, self.END_BOUND + pd.DateOffset(days=1))
+        else:
+            # verify no bound imposed
+            cal = self.calendar_class(self.today, pd.Timestamp("2050-01-01", tz="UTC"))
+            self.assertIsInstance(cal, ExchangeCalendar)
 
     def test_sanity_check_session_lengths(self):
         # make sure that no session is longer than self.MAX_SESSION_HOURS hours
@@ -417,7 +454,7 @@ class ExchangeCalendarTestBase(object):
             self.calendar.minute_to_session_label(minute_before_first_open),
             self.calendar.minute_to_session_label(
                 minute_before_first_open, direction="next"
-            )
+            ),
         ]
 
         unique_session_labels = set(minutes_that_resolve_to_this_session)
@@ -551,7 +588,7 @@ class ExchangeCalendarTestBase(object):
         session_label = self.answers.index[-1]
 
         minute_that_resolves_to_session_label = self.calendar.minute_to_session_label(
-            minute_after_last_close, direction='previous'
+            minute_after_last_close, direction="previous"
         )
 
         self.assertEqual(session_label, minute_that_resolves_to_session_label)
@@ -888,9 +925,7 @@ class ExchangeCalendarTestBase(object):
                 (localized_open.year, localized_open.month, localized_open.day),
             )
 
-            open_ix = open_times.index.searchsorted(
-                pd.Timestamp(date), side="right"
-            )
+            open_ix = open_times.index.searchsorted(pd.Timestamp(date), side="right")
             if open_ix == len(open_times):
                 open_ix -= 1
 
@@ -920,47 +955,13 @@ class ExchangeCalendarTestBase(object):
         has_breaks = self.calendar.has_breaks()
         self.assertEqual(has_breaks, self.HAVE_BREAKS)
 
-
-class TestSessionHasBreak:
-    """Test for ExchangeCalendar.session_has_break."""
-
-    @pytest.fixture
-    def cal_xhkg(self) -> ExchangeCalendar:
-        yield get_calendar("XHKG")
-
-    @pytest.fixture
-    def xhkg_session_no_break(self, cal_xhkg) -> pd.Timestamp:
-        session = pd.Timestamp("2020-12-31", tz="UTC")
-        assert session in cal_xhkg.schedule.index
-        yield session
-
-    @pytest.fixture
-    def xhkg_session_with_break(self, cal_xhkg) -> pd.Timestamp:
-        session = pd.Timestamp("2021-01-04", tz="UTC")
-        assert session in cal_xhkg.schedule.index
-        yield session
-
-    @pytest.fixture
-    def cal_xlon(self) -> ExchangeCalendar:
-        yield get_calendar("XLON")
-
-    @pytest.fixture
-    def xlon_session(self, cal_xlon) -> pd.Timestamp:
-        session = pd.Timestamp("2021-06-07", tz="UTC")
-        assert session in cal_xlon.schedule.index
-        yield session
-
-    def test_session_has_break(
-        self,
-        cal_xhkg,
-        xhkg_session_no_break,
-        xhkg_session_with_break,
-        cal_xlon,
-        xlon_session,
-    ):
-        assert not cal_xhkg.session_has_break(xhkg_session_no_break)
-        assert cal_xhkg.session_has_break(xhkg_session_with_break)
-        assert not cal_xlon.session_has_break(xlon_session)
+    def test_session_has_break(self):
+        if self.SESSION_WITHOUT_BREAK is not None:
+            self.assertFalse(
+                self.calendar.session_has_break(self.SESSION_WITHOUT_BREAK)
+            )
+        if self.SESSION_WITH_BREAK is not None:
+            self.assertTrue(self.calendar.session_has_break(self.SESSION_WITH_BREAK))
 
 
 class EuronextCalendarTestBase(ExchangeCalendarTestBase):

--- a/tests/test_weekday_calendar.py
+++ b/tests/test_weekday_calendar.py
@@ -18,6 +18,7 @@ class WeekdayCalendarTestCase(ExchangeCalendarTestBase, TestCase):
     MAX_SESSION_HOURS = 24
     GAPS_BETWEEN_SESSIONS = False
     HAVE_EARLY_CLOSES = False
+    SESSION_WITHOUT_BREAK = pd.Timestamp("2018-06-13", tz="UTC")
 
     MINUTE_INDEX_TO_SESSION_LABELS_START = pd.Timestamp("2018-01-01", tz=UTC)
     MINUTE_INDEX_TO_SESSION_LABELS_END = pd.Timestamp("2018-04-04", tz=UTC)

--- a/tests/test_xbom_calendar.py
+++ b/tests/test_xbom_calendar.py
@@ -11,6 +11,9 @@ class XBOMCalendarTestCase(ExchangeCalendarTestBase, TestCase):
     answer_key_filename = "xbom"
     calendar_class = XBOMExchangeCalendar
 
+    START_BOUND = T("1997-01-01")
+    END_BOUND = T("2021-12-31")
+
     # BSE is open from 9:15 am to 3:30 pm
     MAX_SESSION_HOURS = 6.25
 
@@ -34,27 +37,3 @@ class XBOMCalendarTestCase(ExchangeCalendarTestBase, TestCase):
 
         for session_label in expected_holidays_2017:
             self.assertNotIn(session_label, self.calendar.all_sessions)
-
-    def test_constrain_construction_dates(self):
-        # the XBOM calendar currently goes from 1997 to 2021, inclusive.
-        with self.assertRaises(ValueError) as e:
-            self.calendar_class(T("1996-12-31"), T("1998-01-01"))
-
-        self.assertEqual(
-            str(e.exception),
-            (
-                "The XBOM holidays are only recorded back to 1997,"
-                " cannot instantiate the XBOM calendar back to 1996."
-            ),
-        )
-
-        with self.assertRaises(ValueError) as e:
-            self.calendar_class(T("1998-01-01"), T("2022-01-03"))
-
-        self.assertEqual(
-            str(e.exception),
-            (
-                "The XBOM holidays are only recorded to 2021,"
-                " cannot instantiate the XBOM calendar for 2022."
-            ),
-        )

--- a/tests/test_xhkg_calendar.py
+++ b/tests/test_xhkg_calendar.py
@@ -15,39 +15,16 @@ class XHKGCalendarTestCase(ExchangeCalendarTestBase, TestCase):
     answer_key_filename = "xhkg"
     calendar_class = XHKGExchangeCalendar
 
+    START_BOUND = T("1960-01-01")
+    END_BOUND = T("2049-12-31")
     HAVE_BREAKS = True
+    SESSION_WITH_BREAK = pd.Timestamp("2018-12-13", tz="UTC")
+    SESSION_WITHOUT_BREAK = pd.Timestamp("2018-12-31", tz="UTC")
 
     MAX_SESSION_HOURS = 6.5
 
     # Asia/Hong_Kong does not have daylight savings
     DAYLIGHT_SAVINGS_DATES = []
-
-    def test_constrain_construction_dates(self):
-        # the lunisolar holidays are currently computed for the years:
-        # [1981, 2050), attempting to create the XHKG calendar outside of that
-        # range should fail.
-
-        with self.assertRaises(ValueError) as e:
-            self.calendar_class(T("1958-12-31"), T("2000-01-01"))
-
-        self.assertEqual(
-            str(e.exception),
-            (
-                "the lunisolar holidays have only been computed back to 1960,"
-                " cannot instantiate the XHKG calendar back to 1958"
-            ),
-        )
-
-        with self.assertRaises(ValueError) as e:
-            self.calendar_class(T("2000-01-01"), T("2050-01-03"))
-
-        self.assertEqual(
-            str(e.exception),
-            (
-                "the lunisolar holidays have only been computed through 2049,"
-                " cannot instantiate the XHKG calendar in 2050"
-            ),
-        )
 
     def test_session_break(self):
         # Test that the calendar correctly reports itself as closed during

--- a/tests/test_xist_calendar.py
+++ b/tests/test_xist_calendar.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 
+import pytest
 import pandas as pd
 from pytz import UTC
 
@@ -15,6 +16,10 @@ class XISTCalendarTestCase(NoDSTExchangeCalendarTestBase, TestCase):
 
     # The XIST is open from 10:00 am to 6:00 pm
     MAX_SESSION_HOURS = 8.0
+
+    @pytest.mark.xfail(reason=("See issue #33"))
+    def test_end_bound(self):
+        super().test_end_bound()
 
     def test_regular_holidays(self):
         all_sessions = self.calendar.all_sessions

--- a/tests/test_xkls_calendar.py
+++ b/tests/test_xkls_calendar.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 
+import pytest
 import pandas as pd
 from pytz import UTC
 
@@ -15,6 +16,14 @@ class XKLSCalendarTestCase(NoDSTExchangeCalendarTestBase, TestCase):
 
     # The XKLS is open from 9AM to 5PM
     MAX_SESSION_HOURS = 8.0
+
+    @pytest.mark.xfail(reason=("See issue #33"))
+    def test_start_bound(self):
+        super().test_start_bound()
+
+    @pytest.mark.xfail(reason=("See issue #33"))
+    def test_end_bound(self):
+        super().test_end_bound()
 
     def test_regular_holidays(self):
         all_sessions = self.calendar.all_sessions

--- a/tests/test_xnys_calendar.py
+++ b/tests/test_xnys_calendar.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 
+import pytest
 import pandas as pd
 from pytz import UTC
 
@@ -14,6 +15,10 @@ class XNYSCalendarTestCase(ExchangeCalendarTestBase, TestCase):
     calendar_class = XNYSExchangeCalendar
 
     MAX_SESSION_HOURS = 6.5
+
+    @pytest.mark.xfail(reason=("See issue #33"))
+    def test_start_bound(self):
+        super().test_start_bound()
 
     def test_2012(self):
         # holidays we expect:

--- a/tests/test_xses_calendar.py
+++ b/tests/test_xses_calendar.py
@@ -11,6 +11,9 @@ class XSESCalendarTestCase(ExchangeCalendarTestBase, TestCase):
     answer_key_filename = "xses"
     calendar_class = XSESExchangeCalendar
 
+    START_BOUND = T("1986-01-01")
+    END_BOUND = T("2021-12-31")
+
     # Singapore stock exchange is open from 9am to 5pm
     # (for now, ignoring lunch break)
     MAX_SESSION_HOURS = 8
@@ -33,27 +36,3 @@ class XSESCalendarTestCase(ExchangeCalendarTestBase, TestCase):
 
         for session_label in expected_holidays_2017:
             self.assertNotIn(session_label, self.calendar.all_sessions)
-
-    def test_constrain_construction_dates(self):
-        # the XSES calendar currently goes from 1999 to 2021, inclusive.
-        with self.assertRaises(ValueError) as e:
-            self.calendar_class(T("1985-12-31"), T("2005-01-01"))
-
-        self.assertEqual(
-            str(e.exception),
-            (
-                "The XSES holidays are only recorded back to 1986,"
-                " cannot instantiate the XSES calendar back to 1985."
-            ),
-        )
-
-        with self.assertRaises(ValueError) as e:
-            self.calendar_class(T("2005-01-01"), T("2022-01-03"))
-
-        self.assertEqual(
-            str(e.exception),
-            (
-                "The XSES holidays are only recorded to 2021,"
-                " cannot instantiate the XSES calendar for 2022."
-            ),
-        )

--- a/tests/test_xshg_calendar.py
+++ b/tests/test_xshg_calendar.py
@@ -14,6 +14,9 @@ class XSHGCalendarTestCase(ExchangeCalendarTestBase, TestCase):
     answer_key_filename = "xshg"
     calendar_class = XSHGExchangeCalendar
 
+    START_BOUND = T("1999-01-01")
+    END_BOUND = T("2025-12-31")
+
     # Shanghai stock exchange is open from 9:30 am to 3pm
     # (for now, ignoring lunch break)
     MAX_SESSION_HOURS = 5.5
@@ -44,27 +47,3 @@ class XSHGCalendarTestCase(ExchangeCalendarTestBase, TestCase):
 
         for session_label in expected_holidays_2017:
             self.assertNotIn(session_label, self.calendar.all_sessions)
-
-    def test_constrain_construction_dates(self):
-        # the XSHG calendar currently goes from 1999 to 2025, inclusive.
-        with self.assertRaises(ValueError) as e:
-            self.calendar_class(T("1998-12-31"), T("2005-01-01"))
-
-        self.assertEqual(
-            str(e.exception),
-            (
-                "The XSHG holidays are only recorded back to 1999,"
-                " cannot instantiate the XSHG calendar back to 1998."
-            ),
-        )
-
-        with self.assertRaises(ValueError) as e:
-            self.calendar_class(T("2005-01-01"), T("2026-01-01"))
-
-        self.assertEqual(
-            str(e.exception),
-            (
-                "The XSHG holidays are only recorded to 2025,"
-                " cannot instantiate the XSHG calendar for 2026."
-            ),
-        )

--- a/tests/test_xtae_calendar.py
+++ b/tests/test_xtae_calendar.py
@@ -1,26 +1,27 @@
 from unittest import TestCase
 
 import pandas as pd
-from pytz import UTC
 
 from exchange_calendars.exchange_calendar_xtae import XTAEExchangeCalendar
-
 from .test_exchange_calendar import ExchangeCalendarTestBase
+from .test_utils import T
 
 
 class XTAECalendarTestCase(ExchangeCalendarTestBase, TestCase):
 
+    SESSION_WITHOUT_BREAK = T("2019-06-12")
+
     # Custom values for start/end test, needed due to XTAE-specific weekmask.
-    TEST_START_END_FIRST = pd.Timestamp("2010-01-02", tz=UTC)
-    TEST_START_END_LAST = pd.Timestamp("2010-01-09", tz=UTC)
-    TEST_START_END_EXPECTED_FIRST = pd.Timestamp("2010-01-03", tz=UTC)
-    TEST_START_END_EXPECTED_LAST = pd.Timestamp("2010-01-07", tz=UTC)
+    TEST_START_END_FIRST = T("2010-01-02")
+    TEST_START_END_LAST = T("2010-01-09")
+    TEST_START_END_EXPECTED_FIRST = T("2010-01-03")
+    TEST_START_END_EXPECTED_LAST = T("2010-01-07")
 
     # XTAE doesn't have early closes.
     HAVE_EARLY_CLOSES = False
 
-    MINUTE_INDEX_TO_SESSION_LABELS_START = pd.Timestamp("2019-01-07", tz=UTC)
-    MINUTE_INDEX_TO_SESSION_LABELS_END = pd.Timestamp("2019-04-07", tz=UTC)
+    MINUTE_INDEX_TO_SESSION_LABELS_START = T("2019-01-07")
+    MINUTE_INDEX_TO_SESSION_LABELS_END = T("2019-04-07")
 
     DAYLIGHT_SAVINGS_DATES = ["2019-03-31", "2019-10-27"]
 

--- a/tests/test_xtks_calendar.py
+++ b/tests/test_xtks_calendar.py
@@ -24,6 +24,7 @@ class XTKSCalendarTestCase(ExchangeCalendarTestBase, TestCase):
     answer_key_filename = "xtks"
     calendar_class = XTKSExchangeCalendar
 
+    START_BOUND = pd.Timestamp("2000-01-01", tz="UTC")
     MAX_SESSION_HOURS = 6
     HAVE_EARLY_CLOSES = False
 


### PR DESCRIPTION
Partially covers #31 by exposing ExchangeCalendar kwargs via get_calendar.

Cache maintained on basis:
* only one copy of any calendar is cached.
* cached copy will be returned if calendar is requested with start and end dates that parse to the same values as those for which the cached version was created. Otherwise cached copy is overwritten with newly created calendar.

@GerryManoim, could I ask that you consider the appropriateness of the 'Notes' section that I've included to the ExchangeCalendar class documentation [here](https://github.com/gerrymanoim/exchange_calendars/pull/37/files#diff-ac7f6dd25cca9fe4be3305261ed8133284c3257c16b46bb27ace7d95c1c8f53cR113). Please offer any suggestions / revisions as you may see fit. Separately, please note this PR includes all commits of #35)

I intend to raise separate PRs for:  
* #33 (which has required new bounds test `test_start_bound` to be marked xfail on a few calendars).
* the `side` option part of #31.