### PR TITLE
Fix conflict between holidays and special dates

### DIFF
--- a/exchange_calendars/exchange_calendar.py
+++ b/exchange_calendars/exchange_calendar.py
@@ -1233,7 +1233,14 @@ class ExchangeCalendar(ABC):
             return pd.Series([], dtype="datetime64[ns, UTC]")
 
         result = pd.concat(merged).sort_index()
-        return result.loc[(result >= start_date) & (result <= end_date)]
+        result = result.loc[(result >= start_date) & (result <= end_date)]
+        # exclude any special date that conincides with a holiday
+        result = result[~result.index.isin(self.adhoc_holidays)]
+        reg_holidays = self.regular_holidays.holidays(
+            start_date.tz_convert(None), end_date.tz_convert(None)
+        )
+        result = result[~result.index.isin(reg_holidays)]
+        return result
 
     def _calculate_special_opens(self, start, end):
         return self._special_dates(

--- a/exchange_calendars/exchange_calendar_xist.py
+++ b/exchange_calendars/exchange_calendar_xist.py
@@ -177,19 +177,5 @@ class XISTExchangeCalendar(ExchangeCalendar):
 
     @property
     def special_closes_adhoc(self):
-        # Some early close days fall on holidays, so we must filter those out
-        # of the early close list
-        collisions = [
-            # CAYS Day on May 19
-            pd.Timestamp("1994-05-19"),
-            # Day before Eid al Fitr observed as holiday in 2003
-            pd.Timestamp("2003-11-24"),
-        ]
-
         early_close_days = EidAlFitrHalfDay + EidAlAdhaHalfDay
-
-        early_close_days = [day for day in early_close_days if day not in collisions]
-
-        return [
-            (self.regular_early_close, early_close_days),
-        ]
+        return [(self.regular_early_close, early_close_days)]

--- a/exchange_calendars/exchange_calendar_xkls.py
+++ b/exchange_calendars/exchange_calendar_xkls.py
@@ -16,7 +16,6 @@
 from datetime import time
 from itertools import chain
 
-import pandas as pd
 from pytz import timezone
 
 from .exchange_calendar import HolidayCalendar, ExchangeCalendar
@@ -122,19 +121,5 @@ class XKLSExchangeCalendar(ExchangeCalendar):
     @property
     def special_closes_adhoc(self):
         # Regular early closes on Chinese New Years Eve, Eid al-Fitr Eve
-        early_close_days = ChineseNewYearsHalfDay + EidAlFitrHalfDay
-
-        collisions = [
-            # Chinese New Year's Eve was a holiday until 2005
-            pd.Timestamp("1997-02-07"),
-            pd.Timestamp("1998-01-28"),
-            pd.Timestamp("2002-02-11"),
-            pd.Timestamp("2003-01-31"),
-            pd.Timestamp("2004-01-21"),
-            # Eid al-Fitr Eve was a holiday in 2003
-            pd.Timestamp("2003-11-24"),
-        ]
-
-        early_close_days = list(set(early_close_days) - set(collisions))
-
+        early_close_days = list(set(ChineseNewYearsHalfDay + EidAlFitrHalfDay))
         return [(self.regular_early_close, early_close_days)]


### PR DESCRIPTION
Fixes #33 by allowing special closes / opens to be defined for dates that are holidays and then filtering out these conflicts in `_special_dates`