### PR TITLE
Fix conflict between holidays and special dates

### DIFF
--- a/exchange_calendars/exchange_calendar.py
+++ b/exchange_calendars/exchange_calendar.py
@@ -306,7 +306,7 @@ class ExchangeCalendar(ABC):
         """
         Returns
         -------
-        list: A list of timestamps representing unplanned closes.
+        list: A list of tz-naive timestamps representing unplanned closes.
         """
         return []
 

--- a/exchange_calendars/exchange_calendar.py
+++ b/exchange_calendars/exchange_calendar.py
@@ -1233,7 +1233,16 @@ class ExchangeCalendar(ABC):
             return pd.Series([], dtype="datetime64[ns, UTC]")
 
         result = pd.concat(merged).sort_index()
-        return result.loc[(result >= start_date) & (result <= end_date)]
+        result = result.loc[(result >= start_date) & (result <= end_date)]
+        # exclude any special date that conincides with a holiday
+        adhoc_holidays = pd.DatetimeIndex(self.adhoc_holidays, tz="UTC")
+        result = result[~result.index.isin(adhoc_holidays)]
+        reg_holidays = self.regular_holidays.holidays(
+            start_date.tz_convert(None), end_date.tz_convert(None)
+        )
+        if not reg_holidays.empty:
+            result = result[~result.index.isin(reg_holidays.tz_localize("UTC"))]
+        return result
 
     def _calculate_special_opens(self, start, end):
         return self._special_dates(

--- a/exchange_calendars/exchange_calendar_asex.py
+++ b/exchange_calendars/exchange_calendar_asex.py
@@ -144,22 +144,22 @@ class ASEXExchangeCalendar(ExchangeCalendar):
     def adhoc_holidays(self):
         debt_crisis = pd.date_range("2015-06-29", "2015-07-31", freq="B")
 
-        debt_crisis_holidays = [pd.Timestamp(str(date), tz=UTC) for date in debt_crisis]
+        debt_crisis_holidays = [pd.Timestamp(str(date)) for date in debt_crisis]
 
         misc_adhoc_holidays = [
             # In 2002, market closed for unknown reason
-            pd.Timestamp("2002-05-07", tz=UTC),
+            pd.Timestamp("2002-05-07"),
             # In 2004, Assumption Day fell on a sunday, observed on a Friday
-            pd.Timestamp("2004-08-13", tz=UTC),
+            pd.Timestamp("2004-08-13"),
             # In 2008, worker strikes closed the market for 2 days in March
-            pd.Timestamp("2008-03-04", tz=UTC),
-            pd.Timestamp("2008-03-05", tz=UTC),
+            pd.Timestamp("2008-03-04"),
+            pd.Timestamp("2008-03-05"),
             # In 2013, May Day strikes closed the market
-            pd.Timestamp("2013-05-07", tz=UTC),
+            pd.Timestamp("2013-05-07"),
             # In 2014, New Year's Eve was observed as a holiday
-            pd.Timestamp("2014-12-31", tz=UTC),
+            pd.Timestamp("2014-12-31"),
             # In 2016, Labour Day fell on a Sunday, observed on Tuesday
-            pd.Timestamp("2016-05-03", tz=UTC),
+            pd.Timestamp("2016-05-03"),
         ]
 
         return list(

--- a/exchange_calendars/exchange_calendar_asex.py
+++ b/exchange_calendars/exchange_calendar_asex.py
@@ -19,7 +19,7 @@ from itertools import chain
 import pandas as pd
 from dateutil.easter import EASTER_ORTHODOX, easter
 from pandas.tseries.holiday import EasterMonday, GoodFriday, Holiday
-from pytz import UTC, timezone
+from pytz import timezone
 
 from .common_holidays import (
     assumption_day,
@@ -43,7 +43,7 @@ def orthodox_easter(start_date="1980", end_date="2021"):
             easter(year, method=EASTER_ORTHODOX)
             for year in range(int(start_date), int(end_date))
         ]
-    ).tz_localize(UTC)
+    )
 
 
 NewYearsDay = new_years_day()

--- a/exchange_calendars/exchange_calendar_bvmf.py
+++ b/exchange_calendars/exchange_calendar_bvmf.py
@@ -122,8 +122,6 @@ AnoNovo = Holiday(
     day=31,
     observance=previous_friday,
 )
-# Brazil hosted World Cup and played Croatia (and won 3-1!)
-CopaDoMundo2014 = Holiday("Copa Do Mundo 2014", month=6, day=12, year=2014)
 
 
 class BVMFExchangeCalendar(ExchangeCalendar):
@@ -170,7 +168,8 @@ class BVMFExchangeCalendar(ExchangeCalendar):
 
     @property
     def adhoc_holidays(self):
-        return [CopaDoMundo2014]
+        # CopaDoMundo2014 Brazil hosted World Cup and played Croatia (and won 3-1!)
+        return [pd.Timestamp("2014-06-12")]
 
     @property
     def regular_holidays(self):

--- a/exchange_calendars/exchange_calendar_iepa.py
+++ b/exchange_calendars/exchange_calendar_iepa.py
@@ -8,7 +8,7 @@ from pandas.tseries.holiday import (
     USPresidentsDay,
     USThanksgivingDay,
 )
-from pytz import UTC, timezone
+from pytz import timezone
 
 from .exchange_calendar import ExchangeCalendar
 from exchange_calendars.exchange_calendar import HolidayCalendar
@@ -69,7 +69,7 @@ class IEPAExchangeCalendar(ExchangeCalendar):
                 USNationalDaysofMourning,
                 # ICE was only closed on the first day of the Hurricane Sandy
                 # closings (was not closed on 2012-10-30)
-                [Timestamp("2012-10-29", tz=UTC)],
+                [Timestamp("2012-10-29")],
             )
         )
 

--- a/exchange_calendars/exchange_calendar_xasx.py
+++ b/exchange_calendars/exchange_calendar_xasx.py
@@ -25,7 +25,7 @@ from pandas.tseries.holiday import (
     sunday_to_monday,
     weekend_to_monday,
 )
-from pytz import UTC, timezone
+from pytz import timezone
 
 from .common_holidays import (
     anzac_day,
@@ -94,7 +94,7 @@ AnzacDay = anzac_day(start_date="2011")
 # also observed as a public holiday. Note that this isn't defined as a
 # rule, because it will happen next in 2095 (and then in  2163), and
 # there isn't a great way to tell how this will be handled at that point.
-EasterTuesday2011AdHoc = Timestamp("2011-04-26", tz=UTC)
+EasterTuesday2011AdHoc = Timestamp("2011-04-26")
 
 QueensBirthday = Holiday(
     "Queen's Birthday",
@@ -124,10 +124,10 @@ LastTradingDayOfCalendarYear = Holiday(
 )
 
 # additional ad-hoc holidays
-NYEMonday1984AdHoc = Timestamp("1984-12-31", tz=UTC)
-NYEMonday1990AdHoc = Timestamp("1990-12-31", tz=UTC)
-Bicentennial1988 = Timestamp("1988-01-25", tz=UTC)
-Y2KTesting = Timestamp("1999-12-31", tz=UTC)
+NYEMonday1984AdHoc = Timestamp("1984-12-31")
+NYEMonday1990AdHoc = Timestamp("1990-12-31")
+Bicentennial1988 = Timestamp("1988-01-25")
+Y2KTesting = Timestamp("1999-12-31")
 
 
 class XASXExchangeCalendar(ExchangeCalendar):

--- a/exchange_calendars/exchange_calendar_xdub.py
+++ b/exchange_calendars/exchange_calendar_xdub.py
@@ -98,7 +98,7 @@ LastTradingDayOfCalendarYear = Holiday(
 
 # Ad hoc closes.
 March1BadWeather = Timestamp("2018-03-01", tz=UTC)
-March2BadWeather = Timestamp("2018-03-02", tz=UTC)
+March2BadWeather = Timestamp("2018-03-02")
 
 
 class XDUBExchangeCalendar(ExchangeCalendar):

--- a/exchange_calendars/exchange_calendar_xdub.py
+++ b/exchange_calendars/exchange_calendar_xdub.py
@@ -98,6 +98,7 @@ LastTradingDayOfCalendarYear = Holiday(
 
 # Ad hoc closes.
 March1BadWeather = Timestamp("2018-03-01", tz=UTC)
+# Ad hoc holidays.
 March2BadWeather = Timestamp("2018-03-02")
 
 

--- a/exchange_calendars/exchange_calendar_xetr.py
+++ b/exchange_calendars/exchange_calendar_xetr.py
@@ -17,7 +17,7 @@ from datetime import time
 
 from pandas import Timestamp
 from pandas.tseries.holiday import EasterMonday, GoodFriday, Holiday, previous_workday
-from pytz import UTC, timezone
+from pytz import timezone
 
 from .common_holidays import (
     boxing_day,
@@ -38,7 +38,7 @@ EuropeanLabourDay = european_labour_day()
 
 # Whit Monday observed in 2007, before it became regularly observed
 # starting in 2015.
-WhitMonday2007AdHoc = Timestamp("2007-05-28", tz=UTC)
+WhitMonday2007AdHoc = Timestamp("2007-05-28")
 
 WhitMonday = whit_monday(start_date="2015-01-01")
 
@@ -47,7 +47,7 @@ DayOfGermanUnity = Holiday(
 )
 
 # Reformation Day was a German national holiday in 2017.
-ReformationDay500thAnniversaryAdHoc = Timestamp("2017-10-31", tz=UTC)
+ReformationDay500thAnniversaryAdHoc = Timestamp("2017-10-31")
 
 ChristmasEve = christmas_eve()
 

--- a/exchange_calendars/exchange_calendar_xfra.py
+++ b/exchange_calendars/exchange_calendar_xfra.py
@@ -17,7 +17,7 @@ from datetime import time
 
 from pandas import Timestamp
 from pandas.tseries.holiday import EasterMonday, GoodFriday, Holiday, previous_workday
-from pytz import UTC, timezone
+from pytz import timezone
 
 from .common_holidays import (
     boxing_day,
@@ -38,7 +38,7 @@ EuropeanLabourDay = european_labour_day()
 
 # Whit Monday observed in 2007, before it became regularly observed
 # starting in 2015.
-WhitMonday2007AdHoc = Timestamp("2007-05-28", tz=UTC)
+WhitMonday2007AdHoc = Timestamp("2007-05-28")
 
 WhitMonday = whit_monday(start_date="2015-01-01")
 
@@ -47,7 +47,7 @@ DayOfGermanUnity = Holiday(
 )
 
 # Reformation Day was a German national holiday in 2017.
-ReformationDay500thAnniversaryAdHoc = Timestamp("2017-10-31", tz=UTC)
+ReformationDay500thAnniversaryAdHoc = Timestamp("2017-10-31")
 
 ChristmasEve = christmas_eve()
 

--- a/exchange_calendars/exchange_calendar_xhkg.py
+++ b/exchange_calendars/exchange_calendar_xhkg.py
@@ -142,87 +142,87 @@ day_after_mid_autumn_festival_dates = mid_autumn_festival_dates + timedelta(1)
 
 HKAdhocClosures = [
     # I dont know these days
-    pd.Timestamp("1970-07-01", tz="UTC"),
-    pd.Timestamp("1971-07-01", tz="UTC"),
-    pd.Timestamp("1973-07-02", tz="UTC"),
-    pd.Timestamp("1974-07-01", tz="UTC"),
-    pd.Timestamp("1975-07-01", tz="UTC"),
-    pd.Timestamp("1976-07-01", tz="UTC"),
-    pd.Timestamp("1977-07-01", tz="UTC"),
-    pd.Timestamp("1979-07-02", tz="UTC"),
-    pd.Timestamp("1980-07-01", tz="UTC"),
-    pd.Timestamp("1981-07-01", tz="UTC"),
-    pd.Timestamp("1982-07-01", tz="UTC"),
-    pd.Timestamp("1971-03-22", tz="UTC"),
-    pd.Timestamp("1971-12-06", tz="UTC"),
-    pd.Timestamp("1971-12-20", tz="UTC"),
-    pd.Timestamp("1975-07-28", tz="UTC"),
-    pd.Timestamp("1985-07-29", tz="UTC"),
+    pd.Timestamp("1970-07-01"),
+    pd.Timestamp("1971-07-01"),
+    pd.Timestamp("1973-07-02"),
+    pd.Timestamp("1974-07-01"),
+    pd.Timestamp("1975-07-01"),
+    pd.Timestamp("1976-07-01"),
+    pd.Timestamp("1977-07-01"),
+    pd.Timestamp("1979-07-02"),
+    pd.Timestamp("1980-07-01"),
+    pd.Timestamp("1981-07-01"),
+    pd.Timestamp("1982-07-01"),
+    pd.Timestamp("1971-03-22"),
+    pd.Timestamp("1971-12-06"),
+    pd.Timestamp("1971-12-20"),
+    pd.Timestamp("1975-07-28"),
+    pd.Timestamp("1985-07-29"),
     # Weather related closures
-    pd.Timestamp("1970-07-16", tz="UTC"),  # 台风Ruby7003
-    pd.Timestamp("1970-09-14", tz="UTC"),  # 台风Georgia7011
-    pd.Timestamp("1971-07-22", tz="UTC"),  # 台风Lucy7114
-    pd.Timestamp("1971-08-31", tz="UTC"),  # 重光纪念日?
-    pd.Timestamp("1973-04-16", tz="UTC"),  # 股灾休市?
-    pd.Timestamp("1973-07-17", tz="UTC"),  # 台风Dot7304
-    pd.Timestamp("1974-04-25", tz="UTC"),  # 英国女王生日
-    pd.Timestamp("1975-10-14", tz="UTC"),  # 台风Elsie7514
-    pd.Timestamp("1978-07-26", tz="UTC"),  # 台风Agnes7807
-    pd.Timestamp("1978-07-27", tz="UTC"),
-    pd.Timestamp("1979-01-26", tz="UTC"),  # 春节补假
-    pd.Timestamp("1979-08-02", tz="UTC"),  # 台风Hope7908
-    pd.Timestamp("1980-05-21", tz="UTC"),  # 台风Georgia8004
-    pd.Timestamp("1980-07-22", tz="UTC"),  # 台风Joy8007
-    pd.Timestamp("1981-04-27", tz="UTC"),  # 英国女王生日
-    pd.Timestamp("1981-07-06", tz="UTC"),  # 台风Lynn8106
-    pd.Timestamp("1981-07-07", tz="UTC"),
-    pd.Timestamp("1981-07-29", tz="UTC"),  # 查理斯王子与戴安娜婚礼
-    pd.Timestamp("1983-09-09", tz="UTC"),  # 台风Ellen8309
-    pd.Timestamp("1985-06-24", tz="UTC"),  # 台风Hal8504
-    pd.Timestamp("1986-04-01", tz="UTC"),  # 复活节星期一翌日
-    pd.Timestamp("1986-10-22", tz="UTC"),  # 英女王伊丽莎白二世访港
-    pd.Timestamp("1987-10-20", tz="UTC"),  # 黑色星期一后,休市4天
-    pd.Timestamp("1987-10-21", tz="UTC"),
-    pd.Timestamp("1987-10-22", tz="UTC"),
-    pd.Timestamp("1987-10-23", tz="UTC"),
-    pd.Timestamp("1988-04-05", tz="UTC"),  # 清明节翌日
-    # Timestamp('1988-06-13', tz='UTC'),  # 英国女王生日
-    pd.Timestamp("1991-06-18", tz="UTC"),  # 英国女王生日翌日
-    pd.Timestamp("1992-07-22", tz="UTC"),  # 台风Cary9207
-    # pd.Timestamp('1993-06-14', tz='UTC'),  # 英国女王生日
-    pd.Timestamp("1993-09-17", tz="UTC"),  # 台风Becky9316
-    pd.Timestamp("1994-06-14", tz="UTC"),  # 英国女王生日翌日,端午节翌日
-    pd.Timestamp("1997-06-30", tz="UTC"),  # 英国女王生日
-    pd.Timestamp("1997-07-02", tz="UTC"),  # 香港回归纪念日翌日
-    pd.Timestamp("1997-08-18", tz="UTC"),  # 抗战胜利纪念日
-    pd.Timestamp("1997-10-02", tz="UTC"),  # 国庆节翌日
-    pd.Timestamp("1998-08-17", tz="UTC"),  # 抗战胜利纪念日
-    pd.Timestamp("1998-10-02", tz="UTC"),  # 国庆节翌日
-    pd.Timestamp("1999-04-06", tz="UTC"),  # 清明节翌日
-    pd.Timestamp("1999-09-16", tz="UTC"),  # 台风约克
-    pd.Timestamp("1999-12-31", tz="UTC"),  # 千年虫
-    pd.Timestamp("2001-07-06", tz="UTC"),  # 台风尤特0104
-    pd.Timestamp("2001-07-25", tz="UTC"),  # 台风玉兔0107
-    # pd.Timestamp(2008-06-25', tz='UTC'),  # 台风风神0806,上午休市
-    pd.Timestamp("2008-08-06", tz="UTC"),  # 台风北冕0809
-    pd.Timestamp("2008-08-22", tz="UTC"),  # 台风鹦鹉0810
-    # pd.Timestamp(2009-09-15', tz='UTC'),  # 台风巨爵0915,上午休市
-    pd.Timestamp("2010-04-06", tz="UTC"),  # 清明节翌日
-    pd.Timestamp("2011-09-29", tz="UTC"),  # 台风纳沙1117
-    # pd.Timestamp(2012-07-24', tz='UTC'),  # 台风韦森特1208,上午休市
-    pd.Timestamp("2012-10-02", tz="UTC"),  # 中秋节补假
-    # pd.Timestamp(2013-05-22', tz='UTC'),  # 暴雨,上午休市
-    pd.Timestamp("2013-08-14", tz="UTC"),  # 台风尤特1311
-    # pd.Timestamp(2013-09-23', tz='UTC'),  # 台风天兔1319,上午休市
-    # pd.Timestamp(2014-09-16', tz='UTC'),  # 台风海鸥1415,上午休市
-    pd.Timestamp("2015-04-07", tz="UTC"),  # 复活节+清明节补假
-    # pd.Timestamp(2015-07-09', tz='UTC'),  # 台风莲花1520,期货夜盘休市
-    pd.Timestamp("2015-09-03", tz="UTC"),  # 抗战70周年纪念
-    # pd.Timestamp(2016-08-01', tz='UTC'),  # 台风妮妲1604,期货夜盘20:55收市
-    pd.Timestamp("2016-08-02", tz="UTC"),  # 台风妮妲1604
-    pd.Timestamp("2016-10-21", tz="UTC"),  # 台风海马1622
-    # pd.Timestamp(2017-06-12', tz='UTC'),  # 台风苗柏1702,期货夜盘17:35休市
-    pd.Timestamp("2017-08-23", tz="UTC"),  # 台风天鸽1713
+    pd.Timestamp("1970-07-16"),  # 台风Ruby7003
+    pd.Timestamp("1970-09-14"),  # 台风Georgia7011
+    pd.Timestamp("1971-07-22"),  # 台风Lucy7114
+    pd.Timestamp("1971-08-31"),  # 重光纪念日?
+    pd.Timestamp("1973-04-16"),  # 股灾休市?
+    pd.Timestamp("1973-07-17"),  # 台风Dot7304
+    pd.Timestamp("1974-04-25"),  # 英国女王生日
+    pd.Timestamp("1975-10-14"),  # 台风Elsie7514
+    pd.Timestamp("1978-07-26"),  # 台风Agnes7807
+    pd.Timestamp("1978-07-27"),
+    pd.Timestamp("1979-01-26"),  # 春节补假
+    pd.Timestamp("1979-08-02"),  # 台风Hope7908
+    pd.Timestamp("1980-05-21"),  # 台风Georgia8004
+    pd.Timestamp("1980-07-22"),  # 台风Joy8007
+    pd.Timestamp("1981-04-27"),  # 英国女王生日
+    pd.Timestamp("1981-07-06"),  # 台风Lynn8106
+    pd.Timestamp("1981-07-07"),
+    pd.Timestamp("1981-07-29"),  # 查理斯王子与戴安娜婚礼
+    pd.Timestamp("1983-09-09"),  # 台风Ellen8309
+    pd.Timestamp("1985-06-24"),  # 台风Hal8504
+    pd.Timestamp("1986-04-01"),  # 复活节星期一翌日
+    pd.Timestamp("1986-10-22"),  # 英女王伊丽莎白二世访港
+    pd.Timestamp("1987-10-20"),  # 黑色星期一后,休市4天
+    pd.Timestamp("1987-10-21"),
+    pd.Timestamp("1987-10-22"),
+    pd.Timestamp("1987-10-23"),
+    pd.Timestamp("1988-04-05"),  # 清明节翌日
+    # Timestamp('1988-06-13'),  # 英国女王生日
+    pd.Timestamp("1991-06-18"),  # 英国女王生日翌日
+    pd.Timestamp("1992-07-22"),  # 台风Cary9207
+    # pd.Timestamp('1993-06-14'),  # 英国女王生日
+    pd.Timestamp("1993-09-17"),  # 台风Becky9316
+    pd.Timestamp("1994-06-14"),  # 英国女王生日翌日,端午节翌日
+    pd.Timestamp("1997-06-30"),  # 英国女王生日
+    pd.Timestamp("1997-07-02"),  # 香港回归纪念日翌日
+    pd.Timestamp("1997-08-18"),  # 抗战胜利纪念日
+    pd.Timestamp("1997-10-02"),  # 国庆节翌日
+    pd.Timestamp("1998-08-17"),  # 抗战胜利纪念日
+    pd.Timestamp("1998-10-02"),  # 国庆节翌日
+    pd.Timestamp("1999-04-06"),  # 清明节翌日
+    pd.Timestamp("1999-09-16"),  # 台风约克
+    pd.Timestamp("1999-12-31"),  # 千年虫
+    pd.Timestamp("2001-07-06"),  # 台风尤特0104
+    pd.Timestamp("2001-07-25"),  # 台风玉兔0107
+    # pd.Timestamp(2008-06-25'),  # 台风风神0806,上午休市
+    pd.Timestamp("2008-08-06"),  # 台风北冕0809
+    pd.Timestamp("2008-08-22"),  # 台风鹦鹉0810
+    # pd.Timestamp(2009-09-15'),  # 台风巨爵0915,上午休市
+    pd.Timestamp("2010-04-06"),  # 清明节翌日
+    pd.Timestamp("2011-09-29"),  # 台风纳沙1117
+    # pd.Timestamp(2012-07-24'),  # 台风韦森特1208,上午休市
+    pd.Timestamp("2012-10-02"),  # 中秋节补假
+    # pd.Timestamp(2013-05-22'),  # 暴雨,上午休市
+    pd.Timestamp("2013-08-14"),  # 台风尤特1311
+    # pd.Timestamp(2013-09-23'),  # 台风天兔1319,上午休市
+    # pd.Timestamp(2014-09-16'),  # 台风海鸥1415,上午休市
+    pd.Timestamp("2015-04-07"),  # 复活节+清明节补假
+    # pd.Timestamp(2015-07-09'),  # 台风莲花1520,期货夜盘休市
+    pd.Timestamp("2015-09-03"),  # 抗战70周年纪念
+    # pd.Timestamp(2016-08-01'),  # 台风妮妲1604,期货夜盘20:55收市
+    pd.Timestamp("2016-08-02"),  # 台风妮妲1604
+    pd.Timestamp("2016-10-21"),  # 台风海马1622
+    # pd.Timestamp(2017-06-12'),  # 台风苗柏1702,期货夜盘17:35休市
+    pd.Timestamp("2017-08-23"),  # 台风天鸽1713
 ]
 
 

--- a/exchange_calendars/exchange_calendar_xist.py
+++ b/exchange_calendars/exchange_calendar_xist.py
@@ -18,7 +18,7 @@ from itertools import chain
 
 import pandas as pd
 from pandas.tseries.holiday import Holiday
-from pytz import UTC, timezone
+from pytz import timezone
 
 from .common_holidays import (
     eid_al_adha_first_day,
@@ -142,15 +142,15 @@ class XISTExchangeCalendar(ExchangeCalendar):
     @property
     def adhoc_holidays(self):
         misc_adhoc = [
-            pd.Timestamp("2002-01-04", tz=UTC),  # Market Holiday
-            pd.Timestamp("2003-02-14", tz=UTC),  # Eid al Adha extra holiday
-            pd.Timestamp("2003-11-21", tz=UTC),  # Terror attacks
-            pd.Timestamp("2003-11-24", tz=UTC),  # Eid al Fitr extra holiday
-            pd.Timestamp("2003-11-28", tz=UTC),  # Eid al Fitr extra holiday
-            pd.Timestamp("2004-01-23", tz=UTC),  # Bad weather
-            pd.Timestamp("2004-12-30", tz=UTC),  # Closure for redenomination
-            pd.Timestamp("2004-12-31", tz=UTC),  # Closure for redenomination
-            pd.Timestamp("2006-01-13", tz=UTC),  # Eid al Adha extra holiday
+            pd.Timestamp("2002-01-04"),  # Market Holiday
+            pd.Timestamp("2003-02-14"),  # Eid al Adha extra holiday
+            pd.Timestamp("2003-11-21"),  # Terror attacks
+            pd.Timestamp("2003-11-24"),  # Eid al Fitr extra holiday
+            pd.Timestamp("2003-11-28"),  # Eid al Fitr extra holiday
+            pd.Timestamp("2004-01-23"),  # Bad weather
+            pd.Timestamp("2004-12-30"),  # Closure for redenomination
+            pd.Timestamp("2004-12-31"),  # Closure for redenomination
+            pd.Timestamp("2006-01-13"),  # Eid al Adha extra holiday
         ]
 
         return list(

--- a/exchange_calendars/exchange_calendar_xist.py
+++ b/exchange_calendars/exchange_calendar_xist.py
@@ -177,19 +177,5 @@ class XISTExchangeCalendar(ExchangeCalendar):
 
     @property
     def special_closes_adhoc(self):
-        # Some early close days fall on holidays, so we must filter those out
-        # of the early close list
-        collisions = [
-            # CAYS Day on May 19
-            pd.Timestamp("1994-05-19"),
-            # Day before Eid al Fitr observed as holiday in 2003
-            pd.Timestamp("2003-11-24"),
-        ]
-
         early_close_days = EidAlFitrHalfDay + EidAlAdhaHalfDay
-
-        early_close_days = [day for day in early_close_days if day not in collisions]
-
-        return [
-            (self.regular_early_close, early_close_days),
-        ]
+        return [(self.regular_early_close, early_close_days)]

--- a/exchange_calendars/exchange_calendar_xjse.py
+++ b/exchange_calendars/exchange_calendar_xjse.py
@@ -18,7 +18,7 @@ from datetime import time
 from pandas import Timestamp
 from pandas.tseries.holiday import Easter, GoodFriday, Holiday, sunday_to_monday
 from pandas.tseries.offsets import Day
-from pytz import UTC, timezone
+from pytz import timezone
 
 from .common_holidays import new_years_day
 from .exchange_calendar import HolidayCalendar, ExchangeCalendar
@@ -135,7 +135,7 @@ class XJSEExchangeCalendar(ExchangeCalendar):
     @property
     def adhoc_holidays(self):
         return [
-            Timestamp(date, tz=UTC)
+            Timestamp(date)
             for date in [
                 # Election holidays
                 "2004-04-14",

--- a/exchange_calendars/exchange_calendar_xkls.py
+++ b/exchange_calendars/exchange_calendar_xkls.py
@@ -16,7 +16,6 @@
 from datetime import time
 from itertools import chain
 
-import pandas as pd
 from pytz import timezone
 
 from .exchange_calendar import HolidayCalendar, ExchangeCalendar
@@ -122,19 +121,5 @@ class XKLSExchangeCalendar(ExchangeCalendar):
     @property
     def special_closes_adhoc(self):
         # Regular early closes on Chinese New Years Eve, Eid al-Fitr Eve
-        early_close_days = ChineseNewYearsHalfDay + EidAlFitrHalfDay
-
-        collisions = [
-            # Chinese New Year's Eve was a holiday until 2005
-            pd.Timestamp("1997-02-07"),
-            pd.Timestamp("1998-01-28"),
-            pd.Timestamp("2002-02-11"),
-            pd.Timestamp("2003-01-31"),
-            pd.Timestamp("2004-01-21"),
-            # Eid al-Fitr Eve was a holiday in 2003
-            pd.Timestamp("2003-11-24"),
-        ]
-
-        early_close_days = list(set(early_close_days) - set(collisions))
-
+        early_close_days = list(set(ChineseNewYearsHalfDay + EidAlFitrHalfDay))
         return [(self.regular_early_close, early_close_days)]

--- a/exchange_calendars/exchange_calendar_xlim.py
+++ b/exchange_calendars/exchange_calendar_xlim.py
@@ -18,7 +18,7 @@ from itertools import chain
 
 import pandas as pd
 from pandas.tseries.holiday import GoodFriday, Holiday
-from pytz import UTC, timezone
+from pytz import timezone
 
 from .common_holidays import (
     all_saints_day,
@@ -63,27 +63,27 @@ NewYearsEve = new_years_eve(end_date="2008")
 # Adhoc Holidays #
 ##################
 ExchangeHolidays = [
-    pd.Timestamp("2009-01-02", tz=UTC),
-    pd.Timestamp("2009-07-27", tz=UTC),
-    pd.Timestamp("2015-07-27", tz=UTC),
-    pd.Timestamp("2015-10-09", tz=UTC),
+    pd.Timestamp("2009-01-02"),
+    pd.Timestamp("2009-07-27"),
+    pd.Timestamp("2015-07-27"),
+    pd.Timestamp("2015-10-09"),
 ]
 
 NationalHolidays = [
-    pd.Timestamp("2015-01-02", tz=UTC),
+    pd.Timestamp("2015-01-02"),
 ]
 
 ASPASummit = [
-    pd.Timestamp("2012-10-01", tz=UTC),
-    pd.Timestamp("2012-10-02", tz=UTC),
+    pd.Timestamp("2012-10-01"),
+    pd.Timestamp("2012-10-02"),
 ]
 
 APECSummit = [
-    pd.Timestamp("2016-11-17", tz=UTC),
-    pd.Timestamp("2016-11-18", tz=UTC),
+    pd.Timestamp("2016-11-17"),
+    pd.Timestamp("2016-11-18"),
 ]
 
-EighthSummitOfTheAmericas = [pd.Timestamp("2018-04-13", tz=UTC)]
+EighthSummitOfTheAmericas = [pd.Timestamp("2018-04-13")]
 
 
 class XLIMExchangeCalendar(ExchangeCalendar):

--- a/exchange_calendars/exchange_calendar_xlon.py
+++ b/exchange_calendars/exchange_calendar_xlon.py
@@ -209,27 +209,27 @@ class XLONExchangeCalendar(ExchangeCalendar):
     def adhoc_holidays(self):
         return [
             # VE-Day Anniversary
-            pd.Timestamp("1995-05-08", tz="UTC"),  # 50th Anniversary
-            pd.Timestamp("2020-05-08", tz="UTC"),  # 75th Anniversary
+            pd.Timestamp("1995-05-08"),  # 50th Anniversary
+            pd.Timestamp("2020-05-08"),  # 75th Anniversary
             # Queen Elizabeth II Jubilees
             # Silver Jubilee
-            pd.Timestamp("1977-06-07", tz="UTC"),
+            pd.Timestamp("1977-06-07"),
             # Golden Jubilee
-            pd.Timestamp("2002-06-03", tz="UTC"),
-            pd.Timestamp("2002-06-04", tz="UTC"),
+            pd.Timestamp("2002-06-03"),
+            pd.Timestamp("2002-06-04"),
             # Diamond Jubilee
-            pd.Timestamp("2012-06-04", tz="UTC"),
-            pd.Timestamp("2012-06-05", tz="UTC"),
+            pd.Timestamp("2012-06-04"),
+            pd.Timestamp("2012-06-05"),
             # Royal Weddings
             # Wedding Day of Princess Anne and Mark Phillips
-            pd.Timestamp("1973-11-14", tz="UTC"),
+            pd.Timestamp("1973-11-14"),
             # Wedding Day of Prince Charles and Diana Spencer
-            pd.Timestamp("1981-07-29", tz="UTC"),
+            pd.Timestamp("1981-07-29"),
             # Wedding Day of Prince William and Catherine Middleton
-            pd.Timestamp("2011-04-29", tz="UTC"),
+            pd.Timestamp("2011-04-29"),
             # Miscellaneous
             # Eve of 3rd Millenium A.D.
-            pd.Timestamp("1999-12-31", tz="UTC"),
+            pd.Timestamp("1999-12-31"),
         ]
 
     @property

--- a/exchange_calendars/exchange_calendar_xmex.py
+++ b/exchange_calendars/exchange_calendar_xmex.py
@@ -18,7 +18,7 @@ from datetime import time
 import pandas as pd
 from pandas.tseries.holiday import MO, GoodFriday, Holiday
 from pandas.tseries.offsets import DateOffset
-from pytz import UTC, timezone
+from pytz import timezone
 
 from .common_holidays import (
     christmas,
@@ -132,5 +132,5 @@ class XMEXExchangeCalendar(ExchangeCalendar):
     def adhoc_holidays(self):
         return [
             # Bicentennial Celebration.
-            pd.Timestamp("2010-09-17", tz=UTC),
+            pd.Timestamp("2010-09-17"),
         ]

--- a/exchange_calendars/exchange_calendar_xmos.py
+++ b/exchange_calendars/exchange_calendar_xmos.py
@@ -18,7 +18,7 @@ from itertools import chain
 
 import pandas as pd
 from pandas.tseries.holiday import Holiday, weekend_to_monday
-from pytz import UTC, timezone
+from pytz import timezone
 
 from .common_holidays import european_labour_day, new_years_day, new_years_eve
 from .exchange_calendar import WEEKDAYS, HolidayCalendar, ExchangeCalendar
@@ -151,80 +151,80 @@ NewYearsEve = new_years_eve(
 # these bridge days is not consistently the rule, so they are treated as adhoc.
 # This means that in the future there may be manual additions needed here.
 new_years_extensions = [
-    pd.Timestamp("2003-01-03", tz=UTC),
-    pd.Timestamp("2013-01-03", tz=UTC),
-    pd.Timestamp("2013-01-04", tz=UTC),
-    pd.Timestamp("2014-01-03", tz=UTC),
+    "2003-01-03",
+    "2013-01-03",
+    "2013-01-04",
+    "2014-01-03",
 ]
 
 orthodox_christmas_extensions = [
-    pd.Timestamp("2003-01-06", tz=UTC),
-    pd.Timestamp("2005-01-10", tz=UTC),
-    pd.Timestamp("2008-01-08", tz=UTC),
-    pd.Timestamp("2009-01-08", tz=UTC),
-    pd.Timestamp("2009-01-09", tz=UTC),
-    pd.Timestamp("2010-01-08", tz=UTC),
-    pd.Timestamp("2011-01-10", tz=UTC),
-    pd.Timestamp("2016-01-08", tz=UTC),
+    "2003-01-06",
+    "2005-01-10",
+    "2008-01-08",
+    "2009-01-08",
+    "2009-01-09",
+    "2010-01-08",
+    "2011-01-10",
+    "2016-01-08",
 ]
 
 defender_of_the_fatherland_extensions = [
-    pd.Timestamp("2006-02-24", tz=UTC),
-    pd.Timestamp("2010-02-22", tz=UTC),
+    "2006-02-24",
+    "2010-02-22",
 ]
 
 womens_day_extensions = [
-    pd.Timestamp("2005-03-07", tz=UTC),
-    pd.Timestamp("2011-03-07", tz=UTC),
-    pd.Timestamp("2012-03-09", tz=UTC),
+    "2005-03-07",
+    "2011-03-07",
+    "2012-03-09",
 ]
 
 labour_day_extensions = [
-    pd.Timestamp("2002-05-02", tz=UTC),
-    pd.Timestamp("2002-05-03", tz=UTC),
-    pd.Timestamp("2003-05-02", tz=UTC),
-    pd.Timestamp("2004-05-04", tz=UTC),
-    pd.Timestamp("2007-04-30", tz=UTC),
-    pd.Timestamp("2008-05-02", tz=UTC),
-    pd.Timestamp("2012-04-30", tz=UTC),
-    pd.Timestamp("2015-05-04", tz=UTC),
-    pd.Timestamp("2016-05-03", tz=UTC),
+    "2002-05-02",
+    "2002-05-03",
+    "2003-05-02",
+    "2004-05-04",
+    "2007-04-30",
+    "2008-05-02",
+    "2012-04-30",
+    "2015-05-04",
+    "2016-05-03",
 ]
 
 victory_day_extensions = [
-    pd.Timestamp("2002-05-10", tz=UTC),
-    pd.Timestamp("2005-05-10", tz=UTC),
-    pd.Timestamp("2006-05-08", tz=UTC),
-    pd.Timestamp("2017-05-08", tz=UTC),
+    "2002-05-10",
+    "2005-05-10",
+    "2006-05-08",
+    "2017-05-08",
 ]
 
 day_of_russia_extensions = [
-    pd.Timestamp("2003-06-13", tz=UTC),
-    pd.Timestamp("2007-06-11", tz=UTC),
-    pd.Timestamp("2008-06-13", tz=UTC),
-    pd.Timestamp("2012-06-11", tz=UTC),
-    pd.Timestamp("2014-06-13", tz=UTC),
+    "2003-06-13",
+    "2007-06-11",
+    "2008-06-13",
+    "2012-06-11",
+    "2014-06-13",
 ]
 
 unity_day_extensions = [
-    pd.Timestamp("2008-11-03", tz=UTC),
-    pd.Timestamp("2010-11-05", tz=UTC),
+    "2008-11-03",
+    "2010-11-05",
 ]
 
 misc_adhoc = [
     # Exchange Holidays.
-    pd.Timestamp("2002-11-07", tz=UTC),
-    pd.Timestamp("2002-11-08", tz=UTC),
-    pd.Timestamp("2002-12-12", tz=UTC),
-    pd.Timestamp("2002-12-13", tz=UTC),
-    pd.Timestamp("2003-11-07", tz=UTC),
-    pd.Timestamp("2003-12-12", tz=UTC),
-    pd.Timestamp("2004-11-08", tz=UTC),
-    pd.Timestamp("2004-12-13", tz=UTC),
-    pd.Timestamp("2008-09-18", tz=UTC),
+    "2002-11-07",
+    "2002-11-08",
+    "2002-12-12",
+    "2002-12-13",
+    "2003-11-07",
+    "2003-12-12",
+    "2004-11-08",
+    "2004-12-13",
+    "2008-09-18",
     # Trading Suspended.
-    pd.Timestamp("2008-10-10", tz=UTC),
-    pd.Timestamp("2008-10-27", tz=UTC),
+    "2008-10-10",
+    "2008-10-27",
 ]
 
 

--- a/exchange_calendars/exchange_calendar_xnze.py
+++ b/exchange_calendars/exchange_calendar_xnze.py
@@ -31,7 +31,7 @@ from pandas.tseries.holiday import (
     previous_workday,
     weekend_to_monday,
 )
-from pytz import UTC, timezone
+from pytz import timezone
 
 from .common_holidays import anzac_day, boxing_day, christmas, new_years_day
 from .exchange_calendar import HolidayCalendar, ExchangeCalendar
@@ -111,17 +111,17 @@ BusinessDayPriorToNewYearsDay = Holiday(
 )
 
 # Further ad-hoc holidays and closures sourced from gaps in index series
-XMAS22DEC86 = Timestamp("1986-12-22", tz=UTC)
-XMAS23DEC86 = Timestamp("1986-12-23", tz=UTC)
-XMAS24DEC86 = Timestamp("1986-12-24", tz=UTC)
-XMAS29DEC86 = Timestamp("1986-12-29", tz=UTC)
-XMAS30DEC86 = Timestamp("1986-12-30", tz=UTC)
-XMAS31DEC86 = Timestamp("1986-12-31", tz=UTC)
-XMAS24DEC90 = Timestamp("1990-12-24", tz=UTC)
-XMAS31DEC90 = Timestamp("1990-12-31", tz=UTC)
-XMAS27DEC91 = Timestamp("1991-12-27", tz=UTC)
-NYDX03JAN92 = Timestamp("1992-01-03", tz=UTC)
-XMAS31DEC99 = Timestamp("1999-12-31", tz=UTC)
+XMAS22DEC86 = Timestamp("1986-12-22")
+XMAS23DEC86 = Timestamp("1986-12-23")
+XMAS24DEC86 = Timestamp("1986-12-24")
+XMAS29DEC86 = Timestamp("1986-12-29")
+XMAS30DEC86 = Timestamp("1986-12-30")
+XMAS31DEC86 = Timestamp("1986-12-31")
+XMAS24DEC90 = Timestamp("1990-12-24")
+XMAS31DEC90 = Timestamp("1990-12-31")
+XMAS27DEC91 = Timestamp("1991-12-27")
+NYDX03JAN92 = Timestamp("1992-01-03")
+XMAS31DEC99 = Timestamp("1999-12-31")
 
 
 class XNZEExchangeCalendar(ExchangeCalendar):

--- a/exchange_calendars/exchange_calendar_xpra.py
+++ b/exchange_calendars/exchange_calendar_xpra.py
@@ -18,7 +18,7 @@ from datetime import time
 import pandas as pd
 from pandas.tseries.holiday import Easter, EasterMonday, Holiday
 from pandas.tseries.offsets import Day
-from pytz import UTC, timezone
+from pytz import timezone
 
 from .common_holidays import (
     christmas,
@@ -147,8 +147,8 @@ class XPRAExchangeCalendar(ExchangeCalendar):
     def adhoc_holidays(self):
         return [
             # Extreme Flooding
-            pd.Timestamp("2002-08-14", tz=UTC),
+            pd.Timestamp("2002-08-14"),
             # Restoration of the Czech Independence Day
-            pd.Timestamp("2004-01-02", tz=UTC),
-            pd.Timestamp("2005-01-03", tz=UTC),
+            pd.Timestamp("2004-01-02"),
+            pd.Timestamp("2005-01-03"),
         ]

--- a/exchange_calendars/exchange_calendar_xsgo.py
+++ b/exchange_calendars/exchange_calendar_xsgo.py
@@ -18,7 +18,7 @@ from datetime import time, timedelta
 import pandas as pd
 from pandas.tseries.holiday import Easter, GoodFriday, Holiday
 from pandas.tseries.offsets import Day
-from pytz import UTC, timezone
+from pytz import timezone
 
 from .common_holidays import (
     all_saints_day,
@@ -245,15 +245,15 @@ class XSGOExchangeCalendar(ExchangeCalendar):
     def adhoc_holidays(self):
         return [
             # Bicentennial Celebration.
-            pd.Timestamp("2010-09-17", tz=UTC),
-            pd.Timestamp("2010-09-20", tz=UTC),
+            pd.Timestamp("2010-09-17"),
+            pd.Timestamp("2010-09-20"),
             # New Year's Day Observed. It is unclear why this happened only for
             # this one year.
-            pd.Timestamp("2017-01-02", tz=UTC),
+            pd.Timestamp("2017-01-02"),
             # Census Day.
-            pd.Timestamp("2017-04-19", tz=UTC),
+            pd.Timestamp("2017-04-19"),
             # Pope Visit.
-            pd.Timestamp("2018-01-16", tz=UTC),
+            pd.Timestamp("2018-01-16"),
         ]
 
     @property

--- a/exchange_calendars/exchange_calendar_xtae.py
+++ b/exchange_calendars/exchange_calendar_xtae.py
@@ -127,15 +127,15 @@ class XTAEExchangeCalendar(ExchangeCalendar):
         return [
             # 2019
             # Election Day
-            pd.Timestamp("2019-04-09", tz="Asia/Jerusalem"),
+            pd.Timestamp("2019-04-09"),
             # Election Day
-            pd.Timestamp("2019-09-17", tz="Asia/Jerusalem"),
+            pd.Timestamp("2019-09-17"),
             # 2020
             # Election Day
-            pd.Timestamp("2020-03-02", tz="Asia/Jerusalem"),
+            pd.Timestamp("2020-03-02"),
             # 2021
             # Election Day
-            pd.Timestamp("2021-03-23", tz="Asia/Jerusalem"),
+            pd.Timestamp("2021-03-23"),
         ]
 
     @property

--- a/exchange_calendars/exchange_calendar_xtse.py
+++ b/exchange_calendars/exchange_calendar_xtse.py
@@ -9,7 +9,7 @@ from pandas.tseries.holiday import (
     Holiday,
     weekend_to_monday,
 )
-from pytz import UTC, timezone
+from pytz import timezone
 
 from .common_holidays import (
     boxing_day,
@@ -91,7 +91,7 @@ BoxingDay = boxing_day()
 
 WeekendBoxingDay = weekend_boxing_day()
 
-September11ClosingsCanada = pd.date_range("2001-09-11", "2001-09-12", tz=UTC)
+September11ClosingsCanada = pd.date_range("2001-09-11", "2001-09-12")
 
 
 class XTSEExchangeCalendar(ExchangeCalendar):

--- a/exchange_calendars/exchange_calendar_xwar.py
+++ b/exchange_calendars/exchange_calendar_xwar.py
@@ -17,7 +17,7 @@ from datetime import time
 
 import pandas as pd
 from pandas.tseries.holiday import EasterMonday, GoodFriday, Holiday
-from pytz import UTC, timezone
+from pytz import timezone
 
 from .common_holidays import (
     all_saints_day,
@@ -137,11 +137,11 @@ class XWARExchangeCalendar(ExchangeCalendar):
     @property
     def adhoc_holidays(self):
         return [
-            pd.Timestamp("2005-04-08", tz=UTC),  # Pope's Funeral.
-            pd.Timestamp("2007-12-31", tz=UTC),  # New Year's Eve (adhoc).
-            pd.Timestamp("2008-05-02", tz=UTC),  # Exchange Holiday.
-            pd.Timestamp("2009-01-02", tz=UTC),  # Exchange Holiday.
-            pd.Timestamp("2013-04-16", tz=UTC),  # Exchange Holiday.
-            pd.Timestamp("2018-01-02", tz=UTC),  # Exchange Holiday.
-            pd.Timestamp("2018-11-12", tz=UTC),  # Independence Holiday.
+            pd.Timestamp("2005-04-08"),  # Pope's Funeral.
+            pd.Timestamp("2007-12-31"),  # New Year's Eve (adhoc).
+            pd.Timestamp("2008-05-02"),  # Exchange Holiday.
+            pd.Timestamp("2009-01-02"),  # Exchange Holiday.
+            pd.Timestamp("2013-04-16"),  # Exchange Holiday.
+            pd.Timestamp("2018-01-02"),  # Exchange Holiday.
+            pd.Timestamp("2018-11-12"),  # Independence Holiday.
         ]

--- a/exchange_calendars/us_holidays.py
+++ b/exchange_calendars/us_holidays.py
@@ -13,7 +13,6 @@ from dateutil.relativedelta import MO, TH, TU
 from pandas import DateOffset, Timestamp
 from pandas.tseries.holiday import Holiday, nearest_workday, sunday_to_monday
 from pandas.tseries.offsets import Day
-from pytz import UTC
 
 from .common_holidays import new_years_day
 from .exchange_calendar import FRIDAY, MONDAY, THURSDAY, TUESDAY, WEDNESDAY
@@ -259,90 +258,90 @@ BattleOfGettysburg = Holiday(
 
 
 November29BacklogRelief = [
-    Timestamp("1929-11-01", tz="UTC"),
-    Timestamp("1929-11-29", tz="UTC"),
+    Timestamp("1929-11-01"),
+    Timestamp("1929-11-29"),
 ]
 
 March33BankHoliday = [
-    Timestamp("1933-03-06", tz="UTC"),
-    Timestamp("1933-03-07", tz="UTC"),
-    Timestamp("1933-03-08", tz="UTC"),
-    Timestamp("1933-03-09", tz="UTC"),
-    Timestamp("1933-03-10", tz="UTC"),
-    Timestamp("1933-03-13", tz="UTC"),
-    Timestamp("1933-03-14", tz="UTC"),
+    Timestamp("1933-03-06"),
+    Timestamp("1933-03-07"),
+    Timestamp("1933-03-08"),
+    Timestamp("1933-03-09"),
+    Timestamp("1933-03-10"),
+    Timestamp("1933-03-13"),
+    Timestamp("1933-03-14"),
 ]
 
 August45VictoryOverJapan = [
-    Timestamp("1945-08-15", tz="UTC"),
-    Timestamp("1945-08-16", tz="UTC"),
+    Timestamp("1945-08-15"),
+    Timestamp("1945-08-16"),
 ]
 
 
 ChristmasEvesAdhoc = [
-    Timestamp("1945-12-24", tz="UTC"),
-    Timestamp("1956-12-24", tz="UTC"),
+    Timestamp("1945-12-24"),
+    Timestamp("1956-12-24"),
 ]
 
-DayAfterChristmasAdhoc = [Timestamp("1958-12-26", tz="UTC")]
+DayAfterChristmasAdhoc = [Timestamp("1958-12-26")]
 
-DayBeforeDecorationAdhoc = [Timestamp("1961-05-29", tz="UTC")]
+DayBeforeDecorationAdhoc = [Timestamp("1961-05-29")]
 
-LincolnsBirthDayAdhoc = [Timestamp("1968-02-12", tz="UTC")]
+LincolnsBirthDayAdhoc = [Timestamp("1968-02-12")]
 
 PaperworkCrisis68 = [
-    Timestamp("1968-06-12", tz="UTC"),
-    Timestamp("1968-06-19", tz="UTC"),
-    Timestamp("1968-06-26", tz="UTC"),
-    Timestamp("1968-07-10", tz="UTC"),
-    Timestamp("1968-07-17", tz="UTC"),
-    Timestamp("1968-07-24", tz="UTC"),
-    Timestamp("1968-07-31", tz="UTC"),
-    Timestamp("1968-08-07", tz="UTC"),
-    Timestamp("1968-08-14", tz="UTC"),
-    Timestamp("1968-08-21", tz="UTC"),
-    Timestamp("1968-08-28", tz="UTC"),
-    Timestamp("1968-09-11", tz="UTC"),
-    Timestamp("1968-09-18", tz="UTC"),
-    Timestamp("1968-09-25", tz="UTC"),
-    Timestamp("1968-10-02", tz="UTC"),
-    Timestamp("1968-10-09", tz="UTC"),
-    Timestamp("1968-10-16", tz="UTC"),
-    Timestamp("1968-10-23", tz="UTC"),
-    Timestamp("1968-10-30", tz="UTC"),
-    Timestamp("1968-11-11", tz="UTC"),
-    Timestamp("1968-11-20", tz="UTC"),
-    Timestamp("1968-12-04", tz="UTC"),
-    Timestamp("1968-12-11", tz="UTC"),
-    Timestamp("1968-12-18", tz="UTC"),
-    Timestamp("1968-12-25", tz="UTC"),
+    Timestamp("1968-06-12"),
+    Timestamp("1968-06-19"),
+    Timestamp("1968-06-26"),
+    Timestamp("1968-07-10"),
+    Timestamp("1968-07-17"),
+    Timestamp("1968-07-24"),
+    Timestamp("1968-07-31"),
+    Timestamp("1968-08-07"),
+    Timestamp("1968-08-14"),
+    Timestamp("1968-08-21"),
+    Timestamp("1968-08-28"),
+    Timestamp("1968-09-11"),
+    Timestamp("1968-09-18"),
+    Timestamp("1968-09-25"),
+    Timestamp("1968-10-02"),
+    Timestamp("1968-10-09"),
+    Timestamp("1968-10-16"),
+    Timestamp("1968-10-23"),
+    Timestamp("1968-10-30"),
+    Timestamp("1968-11-11"),
+    Timestamp("1968-11-20"),
+    Timestamp("1968-12-04"),
+    Timestamp("1968-12-11"),
+    Timestamp("1968-12-18"),
+    Timestamp("1968-12-25"),
 ]
 
-DayAfterIndependenceDayAdhoc = [Timestamp("1968-07-05", tz="UTC")]
+DayAfterIndependenceDayAdhoc = [Timestamp("1968-07-05")]
 
-WeatherSnowClosing = [Timestamp("1969-02-10", tz="UTC")]
+WeatherSnowClosing = [Timestamp("1969-02-10")]
 
-FirstLunarLandingClosing = [Timestamp("1969-07-21", tz="UTC")]
+FirstLunarLandingClosing = [Timestamp("1969-07-21")]
 
-NewYorkCityBlackout77 = [Timestamp("1977-07-14", tz="UTC")]
+NewYorkCityBlackout77 = [Timestamp("1977-07-14")]
 
 
 # http://en.wikipedia.org/wiki/Aftermath_of_the_September_11_attacks
 September11Closings = [
-    Timestamp("2001-09-11", tz=UTC),
-    Timestamp("2001-09-12", tz=UTC),
-    Timestamp("2001-09-13", tz=UTC),
-    Timestamp("2001-09-14", tz=UTC),
+    Timestamp("2001-09-11"),
+    Timestamp("2001-09-12"),
+    Timestamp("2001-09-13"),
+    Timestamp("2001-09-14"),
 ]
 
 # http://en.wikipedia.org/wiki/Hurricane_sandy
 HurricaneSandyClosings = [
-    Timestamp("2012-10-29", tz=UTC),
-    Timestamp("2012-10-30", tz=UTC),
+    Timestamp("2012-10-29"),
+    Timestamp("2012-10-30"),
 ]
 
 # add Hurricane Gloria closing
-HurricaneGloriaClosing = [Timestamp("1985-09-27", tz=UTC)]
+HurricaneGloriaClosing = [Timestamp("1985-09-27")]
 
 
 # National Days of Mourning
@@ -358,13 +357,13 @@ HurricaneGloriaClosing = [Timestamp("1985-09-27", tz=UTC)]
 # added Truman and Johnson to go back to 1970
 # http://s3.amazonaws.com/armstrongeconomics-wp/2013/07/NYSE-Closings.pdf
 USNationalDaysofMourning = [
-    Timestamp("1963-11-25", tz="UTC"),
-    Timestamp("1968-04-09", tz="UTC"),
-    Timestamp("1969-03-31", tz="UTC"),
-    Timestamp("1972-12-28", tz=UTC),
-    Timestamp("1973-01-25", tz=UTC),
-    Timestamp("1994-04-27", tz=UTC),
-    Timestamp("2004-06-11", tz=UTC),
-    Timestamp("2007-01-02", tz=UTC),
-    Timestamp("2018-12-05", tz=UTC),
+    Timestamp("1963-11-25"),
+    Timestamp("1968-04-09"),
+    Timestamp("1969-03-31"),
+    Timestamp("1972-12-28"),
+    Timestamp("1973-01-25"),
+    Timestamp("1994-04-27"),
+    Timestamp("2004-06-11"),
+    Timestamp("2007-01-02"),
+    Timestamp("2018-12-05"),
 ]

--- a/exchange_calendars/xbkk_holidays.py
+++ b/exchange_calendars/xbkk_holidays.py
@@ -7,7 +7,6 @@ from pandas.tseries.holiday import (
     sunday_to_monday,
     weekend_to_monday,
 )
-from pytz import UTC
 
 from .common_holidays import european_labour_day, new_years_day, new_years_eve
 from .exchange_calendar import MONDAY, SUNDAY
@@ -144,42 +143,42 @@ NewYearsEve = new_years_eve(observance=new_years_eve_observance)
 # --------------
 
 new_years_bridge_days = [
-    pd.Timestamp("2002-12-30", tz=UTC),
-    pd.Timestamp("2004-01-02", tz=UTC),
-    pd.Timestamp("2009-01-02", tz=UTC),
-    pd.Timestamp("2013-12-30", tz=UTC),
-    pd.Timestamp("2015-01-02", tz=UTC),
+    pd.Timestamp("2002-12-30"),
+    pd.Timestamp("2004-01-02"),
+    pd.Timestamp("2009-01-02"),
+    pd.Timestamp("2013-12-30"),
+    pd.Timestamp("2015-01-02"),
 ]
 
 asanha_bucha_bridge_days = [
-    pd.Timestamp("2009-07-06", tz=UTC),
-    pd.Timestamp("2016-07-18", tz=UTC),
+    pd.Timestamp("2009-07-06"),
+    pd.Timestamp("2016-07-18"),
 ]
 
 queens_birthday_bridge_days = [
-    pd.Timestamp("2010-08-13", tz=UTC),
-    pd.Timestamp("2014-08-11", tz=UTC),
+    pd.Timestamp("2010-08-13"),
+    pd.Timestamp("2014-08-11"),
 ]
 
 coronation_bridge_days = [
-    pd.Timestamp("2015-05-04", tz=UTC),
-    pd.Timestamp("2016-05-06", tz=UTC),
+    pd.Timestamp("2015-05-04"),
+    pd.Timestamp("2016-05-06"),
 ]
 
 vesak_bridge_days = [
-    pd.Timestamp("2011-05-16", tz=UTC),
+    pd.Timestamp("2011-05-16"),
 ]
 
 misc_adhoc = [
-    pd.Timestamp("2006-04-19", tz=UTC),  # Special Holiday
-    pd.Timestamp("2006-06-12", tz=UTC),  # Special Holiday
-    pd.Timestamp("2006-06-13", tz=UTC),  # Special Holiday
-    pd.Timestamp("2006-09-20", tz=UTC),  # Exchange Holiday
-    pd.Timestamp("2007-12-24", tz=UTC),  # Exchange Holiday
-    pd.Timestamp("2010-05-20", tz=UTC),  # Closure Due to Security Concerns
-    pd.Timestamp("2010-05-21", tz=UTC),  # Closure Due to Security Concerns
-    pd.Timestamp("2012-04-09", tz=UTC),  # Bank Holiday
-    pd.Timestamp("2017-10-26", tz=UTC),  # Cremation of King Bhumibol
+    pd.Timestamp("2006-04-19"),  # Special Holiday
+    pd.Timestamp("2006-06-12"),  # Special Holiday
+    pd.Timestamp("2006-06-13"),  # Special Holiday
+    pd.Timestamp("2006-09-20"),  # Exchange Holiday
+    pd.Timestamp("2007-12-24"),  # Exchange Holiday
+    pd.Timestamp("2010-05-20"),  # Closure Due to Security Concerns
+    pd.Timestamp("2010-05-21"),  # Closure Due to Security Concerns
+    pd.Timestamp("2012-04-09"),  # Bank Holiday
+    pd.Timestamp("2017-10-26"),  # Cremation of King Bhumibol
 ]
 
 # Lunar Holidays

--- a/tests/test_exchange_calendar.py
+++ b/tests/test_exchange_calendar.py
@@ -253,6 +253,11 @@ class ExchangeCalendarTestBase(object):
     def test_calculated_against_csv(self):
         tm.assert_index_equal(self.calendar.schedule.index, self.answers.index)
 
+    def test_adhoc_holidays_specification(self):
+        """adhoc holidays should be tz-naive (#33, #39)."""
+        dti = pd.DatetimeIndex(self.calendar.adhoc_holidays)
+        assert dti.tz is None
+
     def test_is_open_on_minute(self):
         one_minute = pd.Timedelta(minutes=1)
 


### PR DESCRIPTION
NB. Vast majority of changes relate to regularizing timezone of adhoc_holiday dates (23431fe1117be4ef2a24787b493c302979972493)

Fixes #33 by allowing special closes / opens to be defined for dates that are holidays and then filtering out these conflicts in `ExchangeCalendar._special_dates`

Regularizes `adhoc_holiday` dates as tz-naive (previously a mix of tz-naive, "UTC", "Asia/Jerusalem" and defined on one calendar as list of Holiday instances).

- [ ] If merged and #54 merged then remove extensions of `test_start_bound` and/or `test_end_bound` tests marked xfail on test_xist_calendar, test_xkls_calendar and test_xnys_calendar