### PR TITLE
BLD: See if dependabot can manage requirement bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+  - package-ecosystem: "pip" # See documentation for possible values
+    directory: "/etc" # Location of package manifests
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
I _think_ the name actually needs to be `requirements.txt`. If so, will change around the CI in a follow up PR. 