### PR TITLE
BLD: Revert dependabot change

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
-  - package-ecosystem: "pip" # See documentation for possible values
-    directory: "/etc" # Location of package manifests
-    schedule:
-      interval: "daily"
+  # reverted because dependabot can't ignore files
+  # - package-ecosystem: "pip" # See documentation for possible values
+  #   directory: "/etc" # Location of package manifests
+  #   schedule:
+  #     interval: "daily"


### PR DESCRIPTION
Dependabot cannot be made to look at a single file (only a single directory). For now, I'd like to keep the older lock file around, but aggressively update the newer one. Will think about a better way to do this. 