### PR TITLE
Improve parsing

### DIFF
--- a/exchange_calendars/calendar_utils.py
+++ b/exchange_calendars/calendar_utils.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from .calendar_helpers import parse_session
+from .calendar_helpers import parse_date
 from .always_open import AlwaysOpenCalendar
 from .errors import CalendarNameCollision, CyclicCalendarAlias, InvalidCalendarName
 from .exchange_calendar import ExchangeCalendar
@@ -244,11 +244,11 @@ class ExchangeCalendarDispatcher(object):
                 return self._calendars[name]
 
         if kwargs.get("start"):
-            kwargs["start"] = parse_session(kwargs["start"], "start", strict=None)
+            kwargs["start"] = parse_date(kwargs["start"], "start")
         else:
             kwargs["start"] = None
         if kwargs.get("end"):
-            kwargs["end"] = parse_session(kwargs["end"], "end", strict=None)
+            kwargs["end"] = parse_date(kwargs["end"], "end")
         else:
             kwargs["end"] = None
 

--- a/tests/test_calendar_helpers.py
+++ b/tests/test_calendar_helpers.py
@@ -1,112 +1,235 @@
 """Tests for calendar_helpers module."""
 
 from __future__ import annotations
-import pytest
+
+from collections import abc
+import re
+
 import pandas as pd
+import pytest
 
-import exchange_calendars
+from exchange_calendars import (
+    ExchangeCalendar,
+    get_calendar,
+    errors,
+)
 from exchange_calendars import calendar_helpers as m
-from exchange_calendars import errors
-
-# pylint: disable=missing-function-docstring,redefined-outer-name
 
 # TODO tests for next_divider_idx, previous_divider_idx, compute_all_minutes (#15)
 
 
 @pytest.fixture
-def xnys_cal() -> exchange_calendars.ExchangeCalendar:
-    yield exchange_calendars.get_calendar("XNYS")
+def one_minute() -> abc.Iterator[pd.DateOffset]:
+    yield pd.DateOffset(minutes=1)
 
 
 @pytest.fixture
-def xnys_nonsession() -> pd.Timestamp:
-    yield pd.Timestamp("2021-06-06")  # sunday
+def one_day() -> abc.Iterator[pd.DateOffset]:
+    yield pd.DateOffset(days=1)
+
+
+# all fixtures with respect to XHKG
+@pytest.fixture
+def calendar() -> abc.Iterator[ExchangeCalendar]:
+    yield get_calendar("XHKG")
 
 
 @pytest.fixture
-def xnys_session_too_early(xnys_cal) -> pd.Timestamp:
-    yield xnys_cal.first_session - pd.Timedelta(1, "D")
+def param_name() -> abc.Iterator[str]:
+    yield "parameter's_name"
 
 
-@pytest.fixture
-def xnys_session_too_late(xnys_cal) -> pd.Timestamp:
-    yield xnys_cal.last_session + pd.Timedelta(1, "D")
-
-
-@pytest.fixture(params=["parameter_name", None])
-def param_name_options(request) -> str | None:
+@pytest.fixture(params=[True, False])
+def utc(request) -> abc.Iterator[str]:
     yield request.param
 
 
-def test_parse_session_invalid_session_input(
-    xnys_cal,
-    param_name_options,
-    xnys_nonsession,
-    xnys_session_too_early,
-    xnys_session_too_late,
-):
-    name = param_name_options
-
-    session = "not valid input"
-    with pytest.raises(ValueError):
-        m.parse_session(session, name, xnys_cal)
-
-    session = ["not", "valid", "input"]
-    with pytest.raises(TypeError):
-        m.parse_session(session, name, xnys_cal)
-
-    session = pd.Timestamp("2021-06-07", tz="US/Central")
-    with pytest.raises(
-        ValueError, match="A session label must be timezone naive or"
-    ):
-        m.parse_session(session, name, xnys_cal)
-
-    session = pd.Timestamp("2021-06-07 13:33")
-    with pytest.raises(
-        ValueError, match="A session label must have a time component of 00:00"
-    ):
-        m.parse_session(session, name, xnys_cal)
-
-    with pytest.raises(
-        errors.NotSessionError,
-        match="is not a session of calendar",
-    ):
-        m.parse_session(xnys_nonsession, name, xnys_cal, strict=True)
-
-    with pytest.raises(
-        errors.NotSessionError,
-        match="is earlier than the first session of calendar",
-    ):
-        m.parse_session(xnys_session_too_early, name, xnys_cal, strict=True)
-
-    with pytest.raises(
-        errors.NotSessionError,
-        match="is later than the last session of calendar",
-    ):
-        m.parse_session(xnys_session_too_late, name, xnys_cal, strict=True)
+@pytest.fixture(params=["2021-13-13", ("2021-06-06",), "not a timestamp"])
+def malformed(request) -> abc.Iterator[str]:
+    yield request.param
 
 
-@pytest.mark.parametrize(
-    "session",
-    [
-        "2021-06-07",
-        pd.Timestamp("2021-06-07"),
-        pd.Timestamp("2021-06-07", tz="UTC"),
-    ],
+@pytest.fixture
+def minute() -> abc.Iterator[str]:
+    yield "2021-06-02 23:00"
+
+
+@pytest.fixture(
+    params=[
+        "2021-06-02 23:00",
+        pd.Timestamp("2021-06-02 23:00"),
+        pd.Timestamp("2021-06-02 23:00", tz="UTC"),
+    ]
 )
-def test_parse_session_valid_session_input(xnys_cal, session):
-    parsed_session = m.parse_session(session, calendar=xnys_cal)
-    assert isinstance(parsed_session, pd.Timestamp)
-    assert parsed_session.tz.zone == "UTC"
-    assert parsed_session == parsed_session.normalize()
-    assert parsed_session in xnys_cal.schedule.index
+def minute_mult(request) -> abc.Iterator[str | pd.Timestamp]:
+    yield request.param
 
 
-def test_parse_session_valid_nonsession_input(xnys_cal, xnys_nonsession):
-    parsed_session = m.parse_session(
-        xnys_nonsession, calendar=xnys_cal, strict=False
+@pytest.fixture
+def date(calendar) -> abc.Iterator[str]:
+    """Date that does not represent a session of `calendar`."""
+    date_ = "2021-06-05"
+    assert pd.Timestamp(date_, tz="UTC") not in calendar.schedule.index
+    yield date_
+
+
+@pytest.fixture(
+    params=[
+        "2021-06-05",
+        pd.Timestamp("2021-06-05"),
+        pd.Timestamp("2021-06-05", tz="UTC"),
+    ]
+)
+def date_mult(request, calendar) -> abc.Iterator[str | pd.Timestamp]:
+    """Date that does not represent a session of `calendar`."""
+    date_ = request.param
+    try:
+        ts_utc = pd.Timestamp(date_, tz="UTC")
+    except ValueError:
+        ts_utc = date_
+    assert ts_utc not in calendar.schedule.index
+    yield date_
+
+
+@pytest.fixture
+def session() -> abc.Iterator[str]:
+    yield "2021-06-02"
+
+
+@pytest.fixture
+def minute_too_early(calendar, one_minute) -> abc.Iterator[pd.Timestamp]:
+    yield calendar.first_trading_minute - one_minute
+
+
+@pytest.fixture
+def minute_too_late(calendar, one_minute) -> abc.Iterator[pd.Timestamp]:
+    yield calendar.last_trading_minute + one_minute
+
+
+@pytest.fixture
+def date_too_early(calendar, one_day) -> abc.Iterator[pd.Timestamp]:
+    yield calendar.first_session - one_day
+
+
+@pytest.fixture
+def date_too_late(calendar, one_day) -> abc.Iterator[pd.Timestamp]:
+    yield calendar.last_session + one_day
+
+
+def test_parse_timestamp_with_date(date_mult, param_name, utc):
+    date = date_mult
+    date_is_utc_ts = isinstance(date, pd.Timestamp) and date.tz is not None
+    dt = m.parse_timestamp(date, param_name, utc)
+    if not utc and not date_is_utc_ts:
+        assert dt == pd.Timestamp("2021-06-05")
+    else:
+        assert dt == pd.Timestamp("2021-06-05", tz="UTC")
+    assert dt == dt.floor("T")
+
+
+def test_parse_timestamp_with_minute(minute_mult, param_name, utc):
+    minute = minute_mult
+    minute_is_utc_ts = isinstance(minute, pd.Timestamp) and minute.tz is not None
+    dt = m.parse_timestamp(minute, param_name, utc)
+    if not utc and not minute_is_utc_ts:
+        assert dt == pd.Timestamp("2021-06-02 23:00")
+    else:
+        assert dt == pd.Timestamp("2021-06-02 23:00", tz="UTC")
+    assert dt == dt.floor("T")
+
+
+def test_parse_timestamp_error_malformed(malformed, param_name):
+    expected_error = TypeError if isinstance(malformed, tuple) else ValueError
+    error_msg = re.escape(
+        f"Parameter `{param_name}` receieved as '{malformed}' although a Date or"
+        f" Minute must be passed as a pd.Timestamp or a valid single-argument"
+        f" input to pd.Timestamp."
     )
-    assert isinstance(parsed_session, pd.Timestamp)
-    assert parsed_session.tz.zone == "UTC"
-    assert parsed_session == parsed_session.normalize()
-    assert parsed_session not in xnys_cal.schedule.index
+    with pytest.raises(expected_error, match=error_msg):
+        m.parse_timestamp(malformed, param_name)
+
+
+def test_parse_timestamp_error_oob(
+    calendar, param_name, minute_too_early, minute_too_late
+):
+    # by default parses oob
+    assert m.parse_timestamp(minute_too_early, param_name) == minute_too_early
+
+    error_msg = re.escape(
+        f"Parameter `{param_name}` receieved as '{minute_too_early}' although"
+        f" cannot be earlier than the first trading minute of calendar"
+    )
+    with pytest.raises(errors.MinuteOutOfBounds, match=error_msg):
+        m.parse_timestamp(
+            minute_too_early, param_name, raise_oob=True, calendar=calendar
+        )
+
+    # by default parses oob
+    assert m.parse_timestamp(minute_too_late, param_name) == minute_too_late
+
+    error_msg = re.escape(
+        f"Parameter `{param_name}` receieved as '{minute_too_late}' although"
+        f" cannot be later than the last trading minute of calendar"
+    )
+    with pytest.raises(errors.MinuteOutOfBounds, match=error_msg):
+        m.parse_timestamp(
+            minute_too_late, param_name, raise_oob=True, calendar=calendar
+        )
+
+
+def test_parse_date(date_mult, param_name):
+    date = date_mult
+    dt = m.parse_date(date, param_name)
+    assert dt == pd.Timestamp("2021-06-05", tz="UTC")
+
+
+def test_parse_date_errors(calendar, param_name, date_too_early, date_too_late):
+    dt = pd.Timestamp("2021-06-02", tz="US/Central")
+    with pytest.raises(
+        ValueError, match="a Date must be timezone naive or have timezone as 'UTC'"
+    ):
+        m.parse_date(dt, param_name)
+
+    dt = pd.Timestamp("2021-06-02 13:33")
+    with pytest.raises(ValueError, match="a Date must have a time component of 00:00."):
+        m.parse_date(dt, param_name)
+
+    # by default parses oob
+    assert m.parse_date(date_too_early, param_name) == date_too_early
+
+    error_msg = (
+        f"Parameter `{param_name}` receieved as '{date_too_early}' although"
+        f" cannot be earlier than the first session of calendar"
+    )
+    with pytest.raises(errors.DateOutOfBounds, match=re.escape(error_msg)):
+        m.parse_date(date_too_early, param_name, raise_oob=True, calendar=calendar)
+
+    # by default parses oob
+    assert m.parse_date(date_too_late, param_name) == date_too_late
+
+    error_msg = (
+        f"Parameter `{param_name}` receieved as '{date_too_late}' although"
+        f" cannot be later than the last session of calendar"
+    )
+    with pytest.raises(errors.DateOutOfBounds, match=re.escape(error_msg)):
+        m.parse_date(date_too_late, param_name, raise_oob=True, calendar=calendar)
+
+
+def test_parse_session(
+    calendar, session, date, date_too_early, date_too_late, param_name
+):
+    ts = m.parse_session(calendar, session, param_name)
+    assert ts == pd.Timestamp(session, tz="UTC")
+
+    with pytest.raises(errors.NotSessionError, match="not a session of calendar"):
+        m.parse_session(calendar, date, param_name)
+
+    with pytest.raises(
+        errors.NotSessionError, match="is earlier than the first session of calendar"
+    ):
+        m.parse_session(calendar, date_too_early, param_name)
+
+    with pytest.raises(
+        errors.NotSessionError, match="is later than the last session of calendar"
+    ):
+        m.parse_session(calendar, date_too_late, param_name)


### PR DESCRIPTION
Introduces Date and Minute types to define nature of parameters
and distinguish Date from existing Session type.

Refactors `parse_session` to distinguish `parse_timestamp`, `parse_date`
`parse_date` and `parse_session`.

Introduces errors `DateOutOfBounds` and `MinuteOutOfBounds`.

Overhauls parsing tests on `test_calendar_helpers.py`.

Introduces `ExchangeCalendar` methods `first_trading_minute` and
`last_trading_minute`.

---

Anticipated that the introduced ExchangeCalendar methods `first_trading_minute` and `last_trading_minute` will diverge from `first_session_open` and `last_session_close` on any introduction of a 'side' option to define trading minutes at session bounds. For now only distinction is that the new methods return as UTC. 