### PR TITLE
Use proper names for ASEX national holidays.

### DIFF
--- a/exchange_calendars/exchange_calendar_asex.py
+++ b/exchange_calendars/exchange_calendar_asex.py
@@ -39,7 +39,7 @@ Epiphany = epiphany()
 OrthodoxAshMonday = orthodox_easter() - timedelta(48)
 
 NationalHoliday1 = Holiday(
-    "National Holiday 1",
+    "Independence Day",
     month=3,
     day=25,
 )
@@ -55,7 +55,7 @@ OrthodoxWhitMonday = orthodox_easter() + timedelta(50)
 AssumptionDay = assumption_day()
 
 NationalHoliday2 = Holiday(
-    "National Holiday 2",
+    "Ochi Day",
     month=10,
     day=28,
 )


### PR DESCRIPTION
As per https://en.wikipedia.org/wiki/Public_holidays_in_Greece, the two national holidays that appear in the exchange calendar for ASEX have proper names. This PR changes the generic names like `National Holiday 1` to the proper names from the Wikipedia page.