### PR TITLE
Add `trading_index` function

### DIFF
--- a/exchange_calendars/calendar_helpers.py
+++ b/exchange_calendars/calendar_helpers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import typing
 import datetime
+import contextlib
 
 import numpy as np
 import pandas as pd
@@ -276,3 +277,453 @@ def parse_session(
     if ts not in calendar.schedule.index:
         raise errors.NotSessionError(calendar, ts, param_name)
     return ts
+
+
+class _TradingIndex:
+    """Create a trading index.
+
+    Credit to @Stryder-Git at pandas_market_calendars for showing the way
+    with a vectorised solution to creating trading indices.
+
+    Parameters
+    ----------
+    All parameters as ExchangeCalendar.trading_index
+    """
+
+    def __init__(
+        self,
+        calendar: ExchangeCalendar,
+        start: Date,
+        end: Date,
+        period: pd.Timedelta,
+        closed: str,  # Literal["left", "right", "both", "neither"] when min python 3.8
+        force_close: bool,
+        force_break_close: bool,
+        curtail_overlaps: bool,
+    ):
+        self.closed = closed
+        self.force_break_close = force_break_close
+        self.force_close = force_close
+        self.curtail_overlaps = curtail_overlaps
+
+        # get session bound values over requested range
+        slice_start = calendar.all_sessions.searchsorted(start)
+        slice_end = calendar.all_sessions.searchsorted(end, side="right")
+        slce = slice(slice_start, slice_end)
+
+        self.interval_nanos = period.value
+        self.dtype = np.int64 if self.interval_nanos < 3000000000 else np.int32
+
+        self.opens = calendar.market_opens_nanos[slce]
+        self.closes = calendar.market_closes_nanos[slce]
+        self.break_starts = calendar.market_break_starts_nanos[slce]
+        self.break_ends = calendar.market_break_ends_nanos[slce]
+
+        self.mask = self.break_starts != pd.NaT.value  # break mask
+        self.has_break = self.mask.any()
+
+        self.defaults = {
+            "closed": self.closed,
+            "force_close": self.force_close,
+            "force_break_close": self.force_break_close,
+        }
+
+    @property
+    def closed_right(self) -> bool:
+        return self.closed in ["right", "both"]
+
+    @property
+    def closed_left(self) -> bool:
+        return self.closed in ["left", "both"]
+
+    def verify_non_overlapping(self):
+        """Raise IndicesOverlapError if indices will overlap."""
+        if not self.closed_right:
+            return
+
+        def _check(
+            start_nanos: np.ndarray, end_nanos: np.ndarray, next_start_nanos: np.ndarray
+        ):
+            """Raise IndicesOverlap Error if indices would overlap.
+
+            `next_start_nanos` describe start of (sub)session that follows and could
+            overlap with (sub)session described by `start_nanos` and `end_nanos`.
+
+            All inputs should be of same length.
+            """
+            num_intervals = np.ceil((end_nanos - start_nanos) / self.interval_nanos)
+            right = start_nanos + num_intervals * self.interval_nanos
+            if self.closed == "right" and (right > next_start_nanos).any():
+                raise errors.IndicesOverlapError()
+            if self.closed == "both" and (right >= next_start_nanos).any():
+                raise errors.IndicesOverlapError()
+
+        if self.has_break:
+            if not self.force_break_close:
+                _check(
+                    self.opens[self.mask],
+                    self.break_starts[self.mask],
+                    self.break_ends[self.mask],
+                )
+
+        if not self.force_close:
+            opens, closes, next_opens = (
+                self.opens[:-1],
+                self.closes[:-1],
+                self.opens[1:],
+            )
+            _check(opens, closes, next_opens)
+            if self.has_break:
+                mask = self.mask[:-1]
+                _check(self.break_ends[:-1][mask], closes[mask], next_opens[mask])
+
+    def _create_index_for_sessions(
+        self,
+        start_nanos: np.ndarray,
+        end_nanos: np.ndarray,
+        force_close: bool,
+        limit_nanos: np.ndarray | None = None,
+    ) -> np.ndarray:
+        """Create nano array of indices for sessions of given bounds."""
+        if start_nanos.size == 0:
+            return start_nanos
+
+        # evaluate number of indices for each session
+        num_intervals = (end_nanos - start_nanos) / self.interval_nanos
+        num_indices = np.ceil(num_intervals).astype("int")
+
+        if force_close:
+            if self.closed_right:
+                on_freq = (num_intervals == num_indices).all()
+                if not on_freq:
+                    num_indices -= 1  # add the close later
+            else:
+                on_freq = False
+
+        if self.closed == "both":
+            num_indices += 1
+        elif self.closed == "neither":
+            num_indices -= 1
+
+        # by session, evaluate a range of int such that indices of a session
+        # could be evaluted from [ session_open + (freq * i) for i in range ]
+        start = 0 if self.closed_left else 1
+        func = np.vectorize(lambda stop: np.arange(start, stop), otypes=[np.ndarray])
+        stop = num_indices if self.closed_left else num_indices + 1
+        ranges = np.concatenate(func(stop), axis=0, dtype=self.dtype)
+
+        # evaluate index as nano array
+        base = start_nanos.repeat(num_indices)
+        index = base + ranges * self.interval_nanos
+
+        # this is an ugly little clause to cover a very specific rare
+        # circumstance. See comment towards start of `_trading_index`
+        if limit_nanos is not None:
+            limit_nanos = limit_nanos.repeat(num_indices)
+            mask = index > limit_nanos
+            index[mask] = limit_nanos[mask]
+
+        if force_close and not on_freq:
+            index = np.concatenate((index, end_nanos))
+            index.sort()
+
+        return index
+
+    def _trading_index(self) -> np.ndarray:
+        """Create trading index as nano array."""
+
+        if self.has_break:
+            # Create arrays of each session/subsession start and end time ...
+
+            # sessions with breaks
+
+            # limit only passed for index_am. It's there to provide for a rare
+            # circumstance when creating the 'right' side of `trading_index_intervals`
+            # with `self.force_close` = True, `self.force_break_close` = False,
+            # for a calendar with breaks and for a `period` sufficiently high that the
+            # right side of the last interval of the am session will exceed the day
+            # close. Limiting the right side of this last am interval to the day close
+            # ensures that the ordering of the left and right indices remain in sync
+            # (to the contrary the right side gets ahead of itself).
+            # NB not relevant for 'trading_index' as `verify_non_overlapping` will
+            # raise an error in circumstances when limit would otherwise be enforced.
+            if self.force_close and not self.force_break_close:
+                limit = self.closes[self.mask]
+            else:
+                limit = None
+            index_am = self._create_index_for_sessions(
+                self.opens[self.mask],
+                self.break_starts[self.mask],
+                self.force_break_close,
+                limit,
+            )
+
+            index_pm = self._create_index_for_sessions(
+                self.break_ends[self.mask], self.closes[self.mask], self.force_close
+            )
+
+            # sessions without a break
+            index_day = self._create_index_for_sessions(
+                self.opens[~self.mask], self.closes[~self.mask], self.force_close
+            )
+
+            # put it all together
+            index = np.concatenate((index_am, index_pm, index_day))
+            index.sort()
+        else:
+            index = self._create_index_for_sessions(
+                self.opens, self.closes, self.force_close
+            )
+
+        return index
+
+    def trading_index(self) -> pd.DatetimeIndex:
+        """Create trading index as a DatetimeIndex."""
+        self.verify_non_overlapping()
+        index = self._trading_index()
+        return pd.DatetimeIndex(index, tz="UTC")
+
+    @contextlib.contextmanager
+    def _override_defaults(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+        yield
+        for k, v in self.defaults.items():
+            setattr(self, k, v)
+
+    def trading_index_intervals(self) -> pd.IntervalIndex:
+        """Create trading index as a pd.IntervalIndex."""
+        with self._override_defaults(
+            closed="left", force_close=False, force_break_close=False
+        ):
+            left = self._trading_index()
+
+        if not (self.force_close or self.force_break_close):
+            right = left + self.interval_nanos
+        else:
+            with self._override_defaults(closed="right"):
+                right = self._trading_index()
+
+        overlaps_next = right[:-1] > left[1:]
+        if overlaps_next.any():
+            if self.curtail_overlaps:
+                right[:-1][overlaps_next] = left[1:][overlaps_next]
+            else:
+                raise errors.IntervalsOverlapError()
+
+        left = pd.DatetimeIndex(left, tz="UTC")
+        right = pd.DatetimeIndex(right, tz="UTC")
+        return pd.IntervalIndex.from_arrays(left, right, self.closed)
+
+
+# TODO post resolving PR #71:
+#   Move `trading_index` to method of Exchange Calendar
+#   Bring over / revise tests:
+#       include hypothesis fuzz tests - mark so they do not run by default
+#       include tests with known input / output for default test suite
+def trading_index(
+    self,
+    start: Date,
+    end: Date,
+    period: pd.Timedelta | str,
+    intervals: bool = True,
+    closed: str = "left",  # when move to min 3.8 Literal["left", "right", "both", "neither"]
+    force_close: bool = False,
+    force_break_close: bool = False,
+    curtail_overlaps: bool = False,
+    parse: bool = True,
+    _parse: bool = True,
+) -> pd.DatetimeIndex | pd.IntervalIndex:
+    """Create a trading index.
+
+    Create a trading index of given `period` over a given range of dates.
+
+    Execution time is related to the number of indices created. The longer
+    the range of dates covered and/or the shorter the period (i.e. higher
+    the frequency), the longer the execution. Whilst an index with 4000
+    indices might be created in a couple of miliseconds, a high frequency
+    index with 2 million indices might take a second or two.
+
+    `self.side` and which minutes are treated as trading minutes is
+    irrelevant in the evaluation of the trading index.
+
+    Parameters
+    ----------
+    start
+        Start of session range over which to create index.
+
+    end
+        End of session range over which to create index.
+
+    period
+        If `intervals` is True, the length of each interval. If `intervals`
+        is False, the distance between indices. Period described by a
+        pd.Timedelta or str acceptable as a single input to pd.Timedelta.
+        `period` cannot be greater than 1 day.
+
+        Examples of valid `period` input:
+            pd.Timedelta(minutes=15), pd.Timedelta(minutes=15, hours=2)
+            '15min', '15T', '1H', '4h', '1d', '30s', '2s', '500ms'.
+        Examples of invalid `period` input:
+            '15minutes', '2d'.
+
+    intervals : default: True
+        True to return trading index as a pd.IntervalIndex with indices
+        representing explicit intervals.
+
+        False to return trading index as a pd.DatetimeIndex with indices
+        that implicitely represent a period according to `closed`.
+
+        If `period` is '1d' then trading index will always be returned
+        as a pd.DatetimeIndex.
+
+    closed : {"left", "right", "both", "neither"}
+        (ignored if `period` is '1d'.)
+
+        If `intervals` is True:
+            The side that intervals should be closed on. Must be either
+            "left" or "right" (any time during a session must belong to
+            one interval and one interval only).
+
+        If `intervals` is False, then on which side of each period an
+        indice should be defined. The first and last indices of each
+        (sub)session will be defined according to:
+            "left" - include left side of first period, do not include
+                right side of last period.
+            "right" - do not include left side of first period, include
+                right side of last period.
+            "both" - include both left side of first period and right side
+                of last period.
+            "neither" - do not include either left side of first period or
+                right side of last period.
+        NB if `period` is not a factor of the (sub)session length then
+        "right" or "both" will result in an indice being defined after the
+        (sub)session close. See `force_close` and `force_break_close`.
+
+    force_close : default: False
+        (ignored if `period` is '1d'.)
+        (irrelevant if `intervals` is False and `closed` is "left" or
+        "neither".)
+
+        Defines behaviour if right side of a session's last period falls
+        after the session close.
+
+        True - define right side of last period as session close.
+
+        False - define right side of last period after session close.
+        In this case the period represented by the indice will include a
+        non-trading period.
+
+    force_break_close : default: False
+        (ignored if `period` is '1d'.)
+        (irrelevant if `intervals` is False and `closed` is "left" or
+        "neither.)
+
+        Defines behaviour if right side of last pre-break period falls
+        after the start of the break.
+
+        True - define right side of this period as break start.
+
+        False - define right side of this period after break start.
+        In this case the period represented by the indice will include a
+        non-trading period.
+
+    curtail_overlaps : default: False
+        (ignored if `period` is '1d'.)
+        (irrelevant if (`intervals` is False) or (`force_close` and
+        `force_break_close` are True).)
+
+        What action to take in the event that a period ends after the
+        start of the next period. (This can occur if `period` is longer
+        than a break or the period between one session's close and the
+        next session's open.)
+
+            If True, the right of the earlier of two overlapping periods
+            will be curtailed to the left of the latter period. (NB
+            consequently the period length will not be constant for all
+            periods.)
+
+            If False, will raise IntervalsOverlapError.
+
+    parse : default: True
+        Determines if `start` and `end` values are parsed. If these inputs
+        are passed as pd.Timestamp with no time component and tz as UTC
+        then can pass `parse` as False to save around 500µs on the
+        execution.
+
+    Returns
+    -------
+    pd.IntervalIndex or pd.DatetimeIndex
+        Trading index.
+
+        If `intervals` is False or `period` is '1d' then returned as a
+            pd.DatetimeIndex.
+        If `intervals` is True (default) returned as pd.IntervalIndex.
+
+    Raises
+    ------
+    exchange_calendars.errors.IntervalsOverlapError
+        If `intervals` is True and right side of one or more indices
+        would fall after the left of the subsequent indice. This can occur
+        if `period` is longer than a break or period between one
+        session's close and the next session's open.
+
+    exchange_calendars.errors.IntervalsOverlapError
+        If `intervals` is False and an indice would otherwise fall to the
+        right of (later than) the subsequent indice. This can occur if
+        `period` is longer than a break or period between one session's
+        close and the next session's open.
+
+    Notes
+    -----
+    `_parse` included for compatibility. Input will not be parsed if either
+        `parse` or `_parse` are False.
+
+    Credit to @Stryder-Git at pandas_market_calendars for showing the way
+    with a vectorised solution to creating trading indices (a variation of
+    which is employed within the underlying _TradingIndex class).
+    """
+    if parse and _parse:
+        start = parse_date(start, "start", True, self)
+        end = parse_date(end, "end", True, self)
+
+    if not isinstance(period, pd.Timedelta):
+        try:
+            period = pd.Timedelta(period)
+        except ValueError:
+            msg = (
+                f"`period` receieved as '{period}' although takes type 'pd.Timedelta'"
+                " or a type 'str' that is valid as a single input to 'pd.Timedelta'."
+                " Examples of valid input: pd.Timestamp('15T'), '15min', '15T', '1H',"
+                " '4h', '1d', '5s', 500ms'."
+            )
+            raise ValueError(msg) from None
+
+    if period > pd.Timedelta(1, "D"):
+        msg = (
+            f"`period` cannot be greater than one day although received as '{period}'."
+        )
+        raise ValueError(msg)
+
+    if period == pd.Timedelta(1, "D"):
+        return self.sessions_in_range(start, end)
+
+    if intervals and closed in ["both", "neither"]:
+        raise ValueError(f"If `intervals` is True then `closed` cannot be '{closed}'.")
+
+    # method exposes public methods of _TradingIndex.
+    _trading_index = _TradingIndex(
+        self,
+        start,
+        end,
+        period,
+        closed,
+        force_close,
+        force_break_close,
+        curtail_overlaps,
+    )
+
+    if not intervals:
+        return _trading_index.trading_index()
+    else:
+        return _trading_index.trading_index_intervals()

--- a/exchange_calendars/errors.py
+++ b/exchange_calendars/errors.py
@@ -216,3 +216,38 @@ class MinuteOutOfBounds(ValueError):
                 or self.minute > self.calendar.last_trading_minute
             )
         return msg
+
+
+class IndexOverlapError(ValueError):
+    """Periods implied by indices overlap."""
+
+
+class IntervalsOverlapError(IndexOverlapError):
+    """Intervals of requested trading index would overlap."""
+
+    # pylint: disable=missing-return-type-doc
+    def __str__(self):  # noqa: D105
+        return (
+            "Unable to create trading index as intervals would overlap."
+            " This can occur when the frequency is longer than a break or"
+            " the period between one session's close and the next"
+            " session's open. To shorten intervals that would otherwise"
+            " overlap either pass `curtail_overlaps` as True or pass"
+            " `force_close` and/or `force_break_close` as True."
+        )
+
+
+class IndicesOverlapError(IndexOverlapError):
+    """Indices of requested trading index would overlap."""
+
+    # pylint: disable=missing-return-type-doc
+    def __str__(self):  # noqa: D105
+        return (
+            "Unable to create trading index as an indice would fall to the"
+            " right of (later than) the subsequent indice. This can occur"
+            " when the frequency is longer than a break or the frequency"
+            " is longer than the period between one session's close and"
+            " the next session's open. Consider  passing `closed` as"
+            " 'left' or passing `force_close` and/or `force_break_close`"
+            " as True."
+        )


### PR DESCRIPTION
WIP. DO NOT MERGE!
To be merged only after #71 merged/resolved and TODO noted further below have been completed.

Adds `trading_index` function to allow for creating a trading index over a given range of sessions at a given period. Similar to `pandas_market_calendars.date_range` with additional functionality:
 - index can be created as a pd.DatetimeIndex of indices or pd.IntervalIndex of intervals.
 - provides for independent `force_break_close` and `force_close` options
 - takes advantage of `exchange_calendar`s use of nanos for speed improvement (evaluates trading index for XHKG (a calendar with breaks) over a year at 30 minute periods in <2ms).

Credit to @Stryder-Git at `pandas_market_calendars` for showing the way with a vectorised implementation.

TODO post resolution of #71:
- [ ] Move `trading_index` function to method of ExchangeCalendar (leave underlying `_TradingIndex` on `calendar_helpers`).
- [ ] Tests:
  - include hypothesis fuzz tests - mark so they do not run by default (amend CI test parameters to recognise mark). Add hypothesis to dev requirements.
  - include test with known input / output to default test suite (employ Answers to be provided by #71).