### PR TITLE
Migrate to new test base, 0

### DIFF
--- a/tests/test_always_open.py
+++ b/tests/test_always_open.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-from unittest import TestCase
 from collections import abc
 
 import pytest
@@ -9,64 +8,10 @@ from pytz import UTC
 
 from exchange_calendars.always_open import AlwaysOpenCalendar
 from exchange_calendars import ExchangeCalendar
-from .test_exchange_calendar import (
-    ExchangeCalendarTestBase,
-    ExchangeCalendarTestBaseProposal,
-    Answers,
-)
+from .test_exchange_calendar import ExchangeCalendarTestBaseNew, Answers
 
 
-@pytest.mark.skip
-class AlwaysOpenTestCase(ExchangeCalendarTestBase, TestCase):
-
-    answer_key_filename = "24-7"
-    calendar_class = AlwaysOpenCalendar
-    start_date = (pd.Timestamp("2016", tz=UTC),)
-    end_date = (pd.Timestamp("2016-12-31", tz=UTC),)
-    MAX_SESSION_HOURS = 24
-    GAPS_BETWEEN_SESSIONS = False
-    HAVE_EARLY_CLOSES = False
-    SESSION_WITHOUT_BREAK = pd.Timestamp("2016-06-15", tz="UTC")
-
-    MINUTE_INDEX_TO_SESSION_LABELS_START = pd.Timestamp("2016-01-01", tz=UTC)
-    MINUTE_INDEX_TO_SESSION_LABELS_END = pd.Timestamp("2016-04-04", tz=UTC)
-
-    DAYLIGHT_SAVINGS_DATES = ["2016-04-05", "2016-11-01"]
-
-    def test_open_every_day(self):
-        cal = self.calendar
-
-        #    February 2016
-        # Su Mo Tu We Th Fr Sa
-        #     1  2  3  4  5  6
-        #  7  8  9 10 11 12 13
-        # 14 15 16 17 18 19 20
-        # 21 22 23 24 25 26 27
-        # 28 29
-        dates = pd.date_range("2016-02-01", "2016-02-28", tz=UTC)
-        cal_dates = cal.sessions_in_range(dates[0], dates[-1])
-        tm.assert_index_equal(dates, cal_dates)
-
-    def test_open_every_minute(self):
-        cal = self.calendar
-        minutes = pd.date_range("2016-02-01", "2016-02-28 23:59:00", freq="min", tz=UTC)
-        cal_minutes = cal.minutes_for_sessions_in_range(
-            pd.Timestamp("2016-02-01", tz=UTC),
-            pd.Timestamp("2016-02-28", tz=UTC),
-        )
-        tm.assert_index_equal(minutes, cal_minutes)
-
-    def test_start_end(self):
-
-        start = pd.Timestamp("2010-1-3", tz=UTC)
-        end = pd.Timestamp("2010-1-10", tz=UTC)
-        calendar = self.calendar_class(start=start, end=end)
-
-        self.assertTrue(calendar.first_trading_session == start)
-        self.assertTrue(calendar.last_trading_session == end)
-
-
-class TestAlwaysOpenCalendar(ExchangeCalendarTestBaseProposal):
+class TestAlwaysOpenCalendar(ExchangeCalendarTestBaseNew):
     @pytest.fixture(scope="class", params=["left", "right"])
     def all_calendars_with_answers(
         self, request, calendars, answers
@@ -81,3 +26,19 @@ class TestAlwaysOpenCalendar(ExchangeCalendarTestBaseProposal):
     @pytest.fixture(scope="class")
     def max_session_hours(self) -> abc.Iterator[int | float]:
         yield 24
+
+    # Additional tests
+
+    def test_open_every_day(self, default_calendar_with_answers):
+        cal, ans = default_calendar_with_answers
+        dates = pd.date_range(*ans.sessions_range, tz=UTC)
+        tm.assert_index_equal(cal.all_sessions, dates)
+
+    def test_open_every_minute(self, calendars, answers, one_minute):
+        cal, ans = calendars["left"], answers["left"]
+        minutes = pd.date_range(*ans.trading_minutes_range, freq="min", tz=UTC)
+        tm.assert_index_equal(cal.all_minutes, minutes)
+
+        cal = calendars["right"]
+        minutes += one_minute
+        tm.assert_index_equal(cal.all_minutes, minutes)

--- a/tests/test_cmes_calendar.py
+++ b/tests/test_cmes_calendar.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-from unittest import TestCase
 from collections import abc
 
 import pytest
@@ -8,52 +7,10 @@ from pytz import UTC
 
 from exchange_calendars.exchange_calendar_cmes import CMESExchangeCalendar
 from exchange_calendars import ExchangeCalendar
-from .test_exchange_calendar import (
-    ExchangeCalendarTestBase,
-    ExchangeCalendarTestBaseProposal,
-    Answers,
-)
+from .test_exchange_calendar import ExchangeCalendarTestBaseNew, Answers
 
 
-@pytest.mark.skip
-class CMESCalendarTestCase(ExchangeCalendarTestBase, TestCase):
-    answer_key_filename = "cmes"
-    calendar_class = CMESExchangeCalendar
-    GAPS_BETWEEN_SESSIONS = False
-    MAX_SESSION_HOURS = 24
-
-    def test_2016_holidays(self):
-        # good friday: 2016-03-25
-        # christmas (observed)_: 2016-12-26
-        # new years (observed): 2016-01-02
-        for date in ["2016-03-25", "2016-12-26", "2016-01-02"]:
-            self.assertFalse(self.calendar.is_session(pd.Timestamp(date, tz=UTC)))
-
-    def test_2016_early_closes(self):
-        # mlk day: 2016-01-18
-        # presidents: 2016-02-15
-        # mem day: 2016-05-30
-        # july 4: 2016-07-04
-        # labor day: 2016-09-05
-        # thankgiving: 2016-11-24
-        for date in [
-            "2016-01-18",
-            "2016-02-15",
-            "2016-05-30",
-            "2016-07-04",
-            "2016-09-05",
-            "2016-11-24",
-        ]:
-            dt = pd.Timestamp(date, tz=UTC)
-            self.assertTrue(dt in self.calendar.early_closes)
-
-            market_close = self.calendar.schedule.loc[dt].market_close
-            self.assertEqual(
-                12, market_close.tz_localize(UTC).tz_convert(self.calendar.tz).hour
-            )
-
-
-class TestCMESCalendar(ExchangeCalendarTestBaseProposal):
+class TestCMESCalendar(ExchangeCalendarTestBaseNew):
     @pytest.fixture(scope="class", params=["left", "right"])
     def all_calendars_with_answers(
         self, request, calendars, answers
@@ -68,3 +25,27 @@ class TestCMESCalendar(ExchangeCalendarTestBaseProposal):
     @pytest.fixture(scope="class")
     def max_session_hours(self) -> abc.Iterator[int | float]:
         yield 24
+
+    # Additional tests
+
+    def test_2016_holidays(self, default_calendar):
+        # good friday, christmas, new years
+        for date in ["2016-03-25", "2016-12-26", "2016-01-02"]:
+            assert not default_calendar.is_session(
+                pd.Timestamp(date, tz=UTC), _parse=False
+            )
+
+    def test_2016_early_closes(self, default_calendar):
+        cal = default_calendar
+        # TODO HERERE, WOULD THIS BE QUICKER IF COMPARED TWO INDICES?
+        for date in [
+            "2016-01-18",  # mlk day
+            "2016-02-15",  # presidents
+            "2016-05-30",  # mem day
+            "2016-07-04",  # july 4
+            "2016-09-05",  # labor day
+            "2016-11-24",  # thanksgiving
+        ]:
+            dt = pd.Timestamp(date, tz=UTC)
+            assert dt in cal.early_closes
+            assert cal.closes[dt].tz_localize(UTC).tz_convert(cal.tz).hour == 12

--- a/tests/test_exchange_calendar.py
+++ b/tests/test_exchange_calendar.py
@@ -1030,6 +1030,7 @@ class ExchangeCalendarTestBase(object):
             self.assertTrue(self.calendar.session_has_break(self.SESSION_WITH_BREAK))
 
 
+# TODO migrate all subclasses of EuronextCalendarTestBase together under same commit.
 class EuronextCalendarTestBase(ExchangeCalendarTestBase):
     """
     Shared tests for countries on the Euronext exchange.
@@ -1108,6 +1109,8 @@ class EuronextCalendarTestBase(ExchangeCalendarTestBase):
             )
 
 
+# TODO remove this class when all calendars migrated. No longer requried as
+#  `minute_index_to_session_labels` comprehensively tested under new suite.
 class OpenDetectionTestCase(TestCase):
     # This is an extra set of unit tests that were added during a rewrite of
     # `minute_index_to_session_labels` to ensure that the existing
@@ -1157,6 +1160,8 @@ class OpenDetectionTestCase(TestCase):
             self.assertIn("First Bad Minute: {}".format(minute), exc_str)
 
 
+# TODO remove this class when all calendars migrated. No longer requried as
+#  this case is handled by new test base internally.
 class NoDSTExchangeCalendarTestBase(ExchangeCalendarTestBase):
     def test_daylight_savings(self):
         """
@@ -1369,6 +1374,11 @@ class Answers:
         return self.sessions[-1]
 
     @property
+    def sessions_range(self) -> tuple[pd.Timestamp, pd.Timestamp]:
+        """First and last sessions covered by answers."""
+        return self.first_session, self.last_session
+
+    @property
     def first_session_open(self) -> pd.Timestamp:
         """Open time of first session covered by answers."""
         return self.opens[0]
@@ -1387,6 +1397,11 @@ class Answers:
     def last_trading_minute(self) -> pd.Timestamp:
         close = self.last_session_close
         return close if self.side in self.RIGHT_SIDES else close - self.ONE_MIN
+
+    @property
+    def trading_minutes_range(self) -> tuple[pd.Timestamp, pd.Timestamp]:
+        """First and last trading minutes covered by answers."""
+        return self.first_trading_minute, self.last_trading_minute
 
     # --- out-of-bounds properties ---
 
@@ -2441,7 +2456,7 @@ def no_parsing(f: typing.Callable):
     return lambda *args, **kwargs: f(*args, _parse=False, **kwargs)
 
 
-class ExchangeCalendarTestBaseProposal:
+class ExchangeCalendarTestBaseNew:
     """Test base for an ExchangeCalendar.
 
     Notes
@@ -3631,7 +3646,7 @@ class ExchangeCalendarTestBaseProposal:
 
         index = pd.DatetimeIndex(mins).sort_values()
         sessions_labels = f(index)
-        assert sessions_labels.equals(pd.DatetimeIndex(sessions).sort_values())
+        tm.assert_index_equal(sessions_labels, pd.DatetimeIndex(sessions).sort_values())
 
     # Tests for methods that evaluate or interrogate a range of sessions.
 

--- a/tests/test_weekday_calendar.py
+++ b/tests/test_weekday_calendar.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-from unittest import TestCase
 from collections import abc
 
 import pytest
@@ -9,67 +8,10 @@ from pytz import UTC
 
 from exchange_calendars.weekday_calendar import WeekdayCalendar
 from exchange_calendars import ExchangeCalendar
-from .test_exchange_calendar import (
-    ExchangeCalendarTestBase,
-    ExchangeCalendarTestBaseProposal,
-    Answers,
-)
+from .test_exchange_calendar import ExchangeCalendarTestBaseNew, Answers
 
 
-@pytest.mark.skip
-class WeekdayCalendarTestCase(ExchangeCalendarTestBase, TestCase):
-
-    answer_key_filename = "24-5"
-    calendar_class = WeekdayCalendar
-    start_date = pd.Timestamp("2018-01-01", tz=UTC)
-    end_date = pd.Timestamp("2018-12-31", tz=UTC)
-    MAX_SESSION_HOURS = 24
-    GAPS_BETWEEN_SESSIONS = False
-    HAVE_EARLY_CLOSES = False
-    SESSION_WITHOUT_BREAK = pd.Timestamp("2018-06-13", tz="UTC")
-
-    MINUTE_INDEX_TO_SESSION_LABELS_START = pd.Timestamp("2018-01-01", tz=UTC)
-    MINUTE_INDEX_TO_SESSION_LABELS_END = pd.Timestamp("2018-04-04", tz=UTC)
-
-    DAYLIGHT_SAVINGS_DATES = ["2018-04-05", "2018-11-01"]
-
-    def get_session_block(self):
-        # This range is chosen specifically because it is "enclosed" by
-        # adjacent days that are also sessions. This prevents any edge case
-        # issues when looking at market opens or closes.
-        return self.calendar.all_sessions[1:4]
-
-    def test_open_every_weekday(self):
-        calendar = self.calendar
-
-        dates = pd.date_range(self.start_date, self.end_date, tz=UTC)
-        tm.assert_index_equal(
-            calendar.sessions_in_range(dates[0], dates[-1]),
-            # The pandas weekday is defined as Monday=0 to Sunday=6.
-            dates[dates.weekday <= 4],
-        )
-
-    def test_open_every_weekday_minute(self):
-        calendar = self.calendar
-
-        minutes = pd.date_range(
-            self.start_date,
-            # Our calendar should include all the minutes of this last session.
-            self.end_date + pd.Timedelta("1 Day") - pd.Timedelta("1 Minute"),
-            freq="min",
-            tz=UTC,
-        )
-        tm.assert_index_equal(
-            calendar.minutes_for_sessions_in_range(
-                self.start_date,
-                self.end_date,
-            ),
-            # The pandas weekday is defined as Monday=0 to Sunday=6.
-            minutes[minutes.weekday <= 4],
-        )
-
-
-class TestWeekdayCalendar(ExchangeCalendarTestBaseProposal):
+class TestWeekdayCalendar(ExchangeCalendarTestBaseNew):
     @pytest.fixture(scope="class", params=["left", "right"])
     def all_calendars_with_answers(
         self, request, calendars, answers
@@ -84,3 +26,21 @@ class TestWeekdayCalendar(ExchangeCalendarTestBaseProposal):
     @pytest.fixture(scope="class")
     def max_session_hours(self) -> abc.Iterator[int | float]:
         yield 24
+
+    # Additional tests
+
+    def test_open_every_weekday(self, default_calendar_with_answers):
+        cal, ans = default_calendar_with_answers
+        dates = pd.date_range(*ans.sessions_range, freq="B", tz=UTC)
+        tm.assert_index_equal(cal.all_sessions, dates)
+
+    def test_open_every_weekday_minute(self, calendars, answers, one_minute):
+        cal, ans = calendars["left"], answers["left"]
+        minutes = pd.date_range(*ans.trading_minutes_range, freq="min", tz=UTC)
+        # The pandas weekday is defined as Monday=0 to Sunday=6.
+        minutes = minutes[minutes.weekday <= 4]
+        tm.assert_index_equal(cal.all_minutes, minutes)
+
+        cal = calendars["right"]
+        minutes += one_minute
+        tm.assert_index_equal(cal.all_minutes, minutes)

--- a/tests/test_xlon_calendar.py
+++ b/tests/test_xlon_calendar.py
@@ -1,108 +1,14 @@
 from __future__ import annotations
-from unittest import TestCase
 from collections import abc
 
 import pytest
-import pandas as pd
-from pytz import UTC
 
 from exchange_calendars.exchange_calendar_xlon import XLONExchangeCalendar
-
-from .test_exchange_calendar import (
-    ExchangeCalendarTestBase,
-    ExchangeCalendarTestBaseProposal,
-)
+from .test_exchange_calendar import ExchangeCalendarTestBaseNew
+from .test_utils import T
 
 
-class XLONCalendarTestCase(ExchangeCalendarTestBase, TestCase):
-
-    answer_key_filename = "xlon"
-    calendar_class = XLONExchangeCalendar
-
-    # The XLON exchange is open from 8:00 am to 4:30 pm.
-    MAX_SESSION_HOURS = 8.5
-
-    def test_2012(self):
-        expected_holidays_2012 = [
-            pd.Timestamp("2012-01-02", tz=UTC),  # New Year's observed
-            pd.Timestamp("2012-04-06", tz=UTC),  # Good Friday
-            pd.Timestamp("2012-04-09", tz=UTC),  # Easter Monday
-            pd.Timestamp("2012-05-07", tz=UTC),  # May Day
-            pd.Timestamp("2012-06-04", tz=UTC),  # Spring Bank Holiday
-            pd.Timestamp("2012-08-27", tz=UTC),  # Summer Bank Holiday
-            pd.Timestamp("2012-12-25", tz=UTC),  # Christmas
-            pd.Timestamp("2012-12-26", tz=UTC),  # Boxing Day
-        ]
-
-        for session_label in expected_holidays_2012:
-            self.assertNotIn(session_label, self.calendar.all_sessions)
-
-        early_closes_2012 = [
-            pd.Timestamp("2012-12-24", tz=UTC),  # Christmas Eve
-            pd.Timestamp("2012-12-31", tz=UTC),  # New Year's Eve
-        ]
-
-        for early_close_session_label in early_closes_2012:
-            self.assertIn(early_close_session_label, self.calendar.early_closes)
-
-    def test_special_holidays(self):
-        # Spring Bank 2002
-        self.assertNotIn(
-            pd.Timestamp("2002-06-03", tz=UTC),
-            self.calendar.all_sessions,
-        )
-        # Golden Jubilee
-        self.assertNotIn(
-            pd.Timestamp("2002-06-04", tz=UTC),
-            self.calendar.all_sessions,
-        )
-        # Royal Wedding
-        self.assertNotIn(
-            pd.Timestamp("2011-04-29", tz=UTC),
-            self.calendar.all_sessions,
-        )
-        # Spring Bank 2012
-        self.assertNotIn(
-            pd.Timestamp("2012-06-04", tz=UTC),
-            self.calendar.all_sessions,
-        )
-        # DiamondJubilee
-        self.assertNotIn(
-            pd.Timestamp("2012-06-05", tz=UTC),
-            self.calendar.all_sessions,
-        )
-        # VE Day
-        self.assertNotIn(pd.Timestamp("2020-05-08", tz=UTC), self.calendar.all_sessions)
-
-    def test_special_non_holidays(self):
-        # May Bank Holiday was instead observed on VE Day
-        # in 2020.
-        self.assertIn(
-            pd.Timestamp("2020-05-04", tz=UTC),
-            self.calendar.all_sessions,
-        )
-
-    def test_half_days(self):
-
-        half_days = [
-            # In Dec 2010, Christmas Eve and NYE are on Friday,
-            # so they should be half days
-            pd.Timestamp("2010-12-24", tz="Europe/London"),
-            pd.Timestamp("2010-12-31", tz="Europe/London"),
-            # In Dec 2011, Christmas Eve and NYE were both on a Saturday,
-            # so the preceding Fridays (the 23rd and 30th) are half days
-            pd.Timestamp("2011-12-23", tz="Europe/London"),
-            pd.Timestamp("2011-12-30", tz="Europe/London"),
-        ]
-
-        for half_day in half_days:
-            half_day_close_time = self.calendar.next_close(half_day)
-            self.assertEqual(
-                half_day_close_time, half_day + pd.Timedelta(hours=12, minutes=30)
-            )
-
-
-class TestXLONCalendar(ExchangeCalendarTestBaseProposal):
+class TestXLONCalendar(ExchangeCalendarTestBaseNew):
     @pytest.fixture(scope="class")
     def calendar_cls(self) -> abc.Iterator[XLONExchangeCalendar]:
         yield XLONExchangeCalendar
@@ -110,3 +16,61 @@ class TestXLONCalendar(ExchangeCalendarTestBaseProposal):
     @pytest.fixture(scope="class")
     def max_session_hours(self) -> abc.Iterator[int | float]:
         yield 8.5
+
+    # Additional tests
+
+    def test_2012(self, default_calendar):
+        cal = default_calendar
+        expected_holidays_2012 = [
+            T("2012-01-02"),  # New Year's observed
+            T("2012-04-06"),  # Good Friday
+            T("2012-04-09"),  # Easter Monday
+            T("2012-05-07"),  # May Day
+            T("2012-06-04"),  # Spring Bank Holiday
+            T("2012-08-27"),  # Summer Bank Holiday
+            T("2012-12-25"),  # Christmas
+            T("2012-12-26"),  # Boxing Day
+        ]
+
+        for session in expected_holidays_2012:
+            assert session not in cal.all_sessions
+
+        early_closes_2012 = [
+            T("2012-12-24"),  # Christmas Eve
+            T("2012-12-31"),  # New Year's Eve
+        ]
+
+        for session in early_closes_2012:
+            assert session in cal.early_closes
+
+    def test_special_holidays(self, default_calendar):
+        cal = default_calendar
+        special_holidays = [
+            T("2002-06-03"),  # Spring Bank 2002
+            T("2002-06-04"),  # Golden Jubilee
+            T("2011-04-29"),  # Royal Wedding
+            T("2012-06-04"),  # Spring Bank 2012
+            T("2012-06-05"),  # Diamond Jubilee
+            T("2020-05-08"),  # VE Day
+        ]
+
+        for holiday in special_holidays:
+            assert holiday not in cal.all_sessions
+
+    def test_special_non_holidays(self, default_calendar):
+        # May Bank Holiday was instead observed on VE Day in 2020.
+        assert T("2020-05-04") in default_calendar.all_sessions
+
+    def test_specific_early_closes(self, default_calendar):
+        early_closes = [
+            # In Dec 2010, Christmas Eve and NYE are on Friday.
+            T("2010-12-24"),
+            T("2010-12-31"),
+            # In Dec 2011, Christmas Eve and NYE were both on a Saturday,
+            # so preceding Fridays (the 23rd and 30th) are early closes.
+            T("2011-12-23"),
+            T("2011-12-30"),
+        ]
+
+        for session in early_closes:
+            assert session in default_calendar.early_closes


### PR DESCRIPTION
Migrates following test modules to new test base:
  test_always_open.py
  test_weekday_calendar.py
  test_xlon_calendar.py
  test_xhkg_calendar.py
  test_cmes_calendar.py

Also:
  adds properties to Answers.
  Renames `ExchangeCalendarTestBaseProposal` as
  `ExchangeCalendarTestBaseNew`.