### PR TITLE
Migrate to new test base, 1

### DIFF
--- a/tests/test_aixk_calendar.py
+++ b/tests/test_aixk_calendar.py
@@ -1,110 +1,69 @@
-from unittest import TestCase
-
-import pandas as pd
-from pytz import UTC
+import pytest
 
 from exchange_calendars.exchange_calendar_aixk import AIXKExchangeCalendar
-from .test_exchange_calendar import ExchangeCalendarTestBase
+from .test_exchange_calendar import ExchangeCalendarTestBaseNew
 from .test_utils import T
 
 
-class AIXKCalendarTestCase(ExchangeCalendarTestBase, TestCase):
+class TestAIXKCalendar(ExchangeCalendarTestBaseNew):
+    @pytest.fixture(scope="class")
+    def calendar_cls(self):
+        yield AIXKExchangeCalendar
 
-    answer_key_filename = "aixk"
-    calendar_class = AIXKExchangeCalendar
+    @pytest.fixture(scope="class")
+    def max_session_hours(self):
+        yield 6
 
-    START_BOUND = T("2017-01-01")
+    @pytest.fixture(scope="class")
+    def start_bound(self):
+        yield T("2017-01-01")
 
-    SESSION_WITHOUT_BREAK = T("2021-07-14")
-
-    # The AIXK is open from 11:00 to 5:00PM
-    MAX_SESSION_HOURS = 6
-
-    HAVE_EARLY_CLOSES = False
-
-    # Exchange began operating in 2019
-    DAYLIGHT_SAVINGS_DATES = []
-
-    MINUTE_INDEX_TO_SESSION_LABELS_START = T("2021-01-06")
-    MINUTE_INDEX_TO_SESSION_LABELS_END = T("2021-04-06")
-
-    TEST_START_END_FIRST = T("2021-01-03")
-    TEST_START_END_LAST = T("2021-01-10")
-    TEST_START_END_EXPECTED_FIRST = T("2021-01-04")
-    TEST_START_END_EXPECTED_LAST = T("2021-01-08")
-
-    def test_regular_holidays(self):
-        all_sessions = self.calendar.all_sessions
-
-        expected_holidays = [
-            pd.Timestamp("2021-01-01", tz=UTC),  # New Year’s Day
-            pd.Timestamp("2021-01-07", tz=UTC),  # Orthodox Christmas Day
-            pd.Timestamp("2021-03-08", tz=UTC),  # International Women’s Day
-            pd.Timestamp("2021-03-22", tz=UTC),  # Nauryz Holiday
-            pd.Timestamp("2021-03-23", tz=UTC),  # Nauryz Holiday
-            pd.Timestamp("2021-03-24", tz=UTC),  # Nauryz Holiday
-            pd.Timestamp("2021-05-03", tz=UTC),  # Kazakhstan People Solidarity Day
-            pd.Timestamp("2021-05-07", tz=UTC),  # Defender’s Day
-            pd.Timestamp("2021-05-10", tz=UTC),  # Victory Day Holiday
-            pd.Timestamp("2021-07-06", tz=UTC),  # Capital City Day
-            pd.Timestamp("2021-07-20", tz=UTC),  # Kurban Ait Holiday
-            pd.Timestamp("2021-08-30", tz=UTC),  # Constitution Day
-            pd.Timestamp("2021-12-01", tz=UTC),  # First President Day
-            pd.Timestamp("2021-12-16", tz=UTC),  # Independence Day
-            pd.Timestamp("2021-12-17", tz=UTC),  # Independence Day Holiday
-        ]
-
-        for holiday_label in expected_holidays:
-            self.assertNotIn(holiday_label, all_sessions)
-
-    def test_holidays_fall_on_weekend_are_moved(self):
-        all_sessions = self.calendar.all_sessions
-
-        # National holidays that fall on a weekend should be made
-        # up
-        expected_sessions = [
+    @pytest.fixture(scope="class")
+    def regular_holidays_sample(self):
+        yield [
+            # 2021
+            "2021-01-01",  # New Year’s Day
+            "2021-01-07",  # Orthodox Christmas Day
+            "2021-03-08",  # International Women’s Day
+            "2021-03-22",  # Nauryz Holiday
+            "2021-03-23",  # Nauryz Holiday
+            "2021-03-24",  # Nauryz Holiday
+            "2021-05-03",  # Kazakhstan People Solidarity Day
+            "2021-05-07",  # Defender’s Day
+            "2021-05-10",  # Victory Day Holiday
+            "2021-07-06",  # Capital City Day
+            "2021-07-20",  # Kurban Ait Holiday
+            "2021-08-30",  # Constitution Day
+            "2021-12-01",  # First President Day
+            "2021-12-16",  # Independence Day
+            "2021-12-17",  # Independence Day Holiday
+            # Holiday's made up when fall on weekend.
             # Last day of Nauryz on Saturday, 23th
-            pd.Timestamp("2019-03-21"),
-            pd.Timestamp("2019-03-22"),
-            pd.Timestamp("2019-03-25"),
+            "2019-03-21",
+            "2019-03-22",
+            "2019-03-25",
             # First day of Nauryz on Sunday
-            pd.Timestamp("2020-03-22"),
-            pd.Timestamp("2020-03-23"),
-            pd.Timestamp("2020-03-24"),
+            "2020-03-22",
+            "2020-03-23",
+            "2020-03-24",
             # Women's day on Sunday, Mar 8th
-            pd.Timestamp("2020-03-09"),
+            "2020-03-09",
             # Capital day on Sunday, Jul 7th
-            pd.Timestamp("2019-07-08"),
+            "2019-07-08",
         ]
 
-        for session_label in expected_sessions:
-            self.assertNotIn(session_label, all_sessions)
-
-    def test_adhoc_holidays(self):
-        all_sessions = self.calendar.all_sessions
-
-        expected_holidays = [
-            # Bridge Day between Women's day - Weekend
-            pd.Timestamp("2018-03-09"),
-            # Bridge Day between Weekend - Kazakhstan People Solidarity Day
-            pd.Timestamp("2018-04-30"),
-            # Bridge Day between Defender's Day - Victory Day
-            pd.Timestamp("2018-05-08"),
-            # Bridge Day between Constitution Day - Weekend
-            pd.Timestamp("2018-08-31"),
-            # Bridge Day between New Year's Eve - New Year's day
-            pd.Timestamp("2018-12-31"),
-            # Bridge Day between Victory Day - Weekend
-            pd.Timestamp("2019-05-10"),
-            # Bridge Day between New Year's day - Weekend
-            pd.Timestamp("2020-01-03"),
-            # Bridge Day between Independence day - Weekend
-            pd.Timestamp("2020-12-18"),
-            # Bridge Day between Weekend - Capital City day
-            pd.Timestamp("2021-06-05"),
-            # Bridge Day between Weekend - Women's day
-            pd.Timestamp("2022-03-07"),
+    @pytest.fixture(scope="class")
+    def adhoc_holidays_sample(self):
+        # Bridge Days
+        yield [
+            "2018-03-09",  # between Women's day - Weekend
+            "2018-04-30",  # between Weekend - Kazakhstan People Solidarity Day
+            "2018-05-08",  # between Defender's Day - Victory Day
+            "2018-08-31",  # between Constitution Day - Weekend
+            "2018-12-31",  # between New Year's Eve - New Year's day
+            "2019-05-10",  # between Victory Day - Weekend
+            "2020-01-03",  # between New Year's day - Weekend
+            "2020-12-18",  # between Independence day - Weekend
+            "2021-06-05",  # between Weekend - Capital City day
+            "2022-03-07",  # between Weekend - Women's day
         ]
-
-        for holiday_label in expected_holidays:
-            self.assertNotIn(holiday_label, all_sessions)

--- a/tests/test_always_open.py
+++ b/tests/test_always_open.py
@@ -1,33 +1,26 @@
-from __future__ import annotations
-from collections import abc
-
 import pytest
 import pandas as pd
 import pandas.testing as tm
 from pytz import UTC
 
 from exchange_calendars.always_open import AlwaysOpenCalendar
-from exchange_calendars import ExchangeCalendar
-from .test_exchange_calendar import ExchangeCalendarTestBaseNew, Answers
+from .test_exchange_calendar import ExchangeCalendarTestBaseNew
 
 
 class TestAlwaysOpenCalendar(ExchangeCalendarTestBaseNew):
     @pytest.fixture(scope="class", params=["left", "right"])
-    def all_calendars_with_answers(
-        self, request, calendars, answers
-    ) -> abc.Iterator[ExchangeCalendar, Answers]:
-        """Parameterized calendars and answers for each side."""
+    def all_calendars_with_answers(self, request, calendars, answers):
         yield (calendars[request.param], answers[request.param])
 
     @pytest.fixture(scope="class")
-    def calendar_cls(self) -> abc.Iterator[ExchangeCalendar]:
+    def calendar_cls(self):
         yield AlwaysOpenCalendar
 
     @pytest.fixture(scope="class")
-    def max_session_hours(self) -> abc.Iterator[int | float]:
+    def max_session_hours(self):
         yield 24
 
-    # Additional tests
+    # Calendar-specific tests
 
     def test_open_every_day(self, default_calendar_with_answers):
         cal, ans = default_calendar_with_answers

--- a/tests/test_asex_calendar.py
+++ b/tests/test_asex_calendar.py
@@ -1,180 +1,140 @@
-from unittest import TestCase
-
 import pandas as pd
-from pytz import UTC
+import pytest
 
 from exchange_calendars.exchange_calendar_asex import ASEXExchangeCalendar
+from .test_exchange_calendar import ExchangeCalendarTestBaseNew
 
-from .test_exchange_calendar import ExchangeCalendarTestBase
 
+class TestASEXCalendar(ExchangeCalendarTestBaseNew):
+    @pytest.fixture(scope="class")
+    def calendar_cls(self):
+        yield ASEXExchangeCalendar
 
-class ASEXCalendarTestCase(ExchangeCalendarTestBase, TestCase):
+    @pytest.fixture(scope="class")
+    def max_session_hours(self):
+        # The ASEX is open from 10:00 to 5:20PM on its longest trading day
+        yield 7 + (1 / 3)
 
-    answer_key_filename = "asex"
-    calendar_class = ASEXExchangeCalendar
-
-    # The ASEX is open from 10:00 to 5:20PM on its longest trading day
-    MAX_SESSION_HOURS = 7 + (1 / 3)
-
-    HAVE_EARLY_CLOSES = False
-
-    DAYLIGHT_SAVINGS_DATES = ["2018-03-26", "2018-10-29"]
-
-    def test_regular_holidays(self):
-        all_sessions = self.calendar.all_sessions
-
-        expected_holidays = [
-            pd.Timestamp("2019-01-01", tz=UTC),  # New Year's Day
-            pd.Timestamp("2017-01-06", tz=UTC),  # Epiphany
-            pd.Timestamp("2019-03-11", tz=UTC),  # Orthodox Ash Monday
-            pd.Timestamp("2019-03-25", tz=UTC),  # National Holiday
-            pd.Timestamp("2019-04-19", tz=UTC),  # Good Friday
-            pd.Timestamp("2019-04-22", tz=UTC),  # Easter Monday
-            pd.Timestamp("2019-04-26", tz=UTC),  # Orthodox Good Friday
-            pd.Timestamp("2019-04-29", tz=UTC),  # Orthodox Easter Monday
-            pd.Timestamp("2019-05-01", tz=UTC),  # Labour Day
-            pd.Timestamp("2019-06-17", tz=UTC),  # Orthodox Whit Monday
-            pd.Timestamp("2019-08-15", tz=UTC),  # Assumption Day
-            pd.Timestamp("2019-10-28", tz=UTC),  # National Holiday
-            pd.Timestamp("2019-12-24", tz=UTC),  # Christmas Eve
-            pd.Timestamp("2019-12-25", tz=UTC),  # Christmas Day
-            pd.Timestamp("2019-12-26", tz=UTC),  # Second Day of Christmas
-        ]
-
-        for holiday_label in expected_holidays:
-            self.assertNotIn(holiday_label, all_sessions)
-
-    def test_holidays_fall_on_weekend(self):
-        all_sessions = self.calendar.all_sessions
-
-        # All holidays that fall on a weekend should not be made
-        # up, so ensure surrounding days are open market
-        expected_sessions = [
-            # New Years Day on Sunday, Jan 1st
-            pd.Timestamp("2011-12-30", tz=UTC),
-            pd.Timestamp("2012-01-02", tz=UTC),
-            # Epiphany on Sunday, Jan 6th
-            pd.Timestamp("2019-01-04", tz=UTC),
-            pd.Timestamp("2019-01-07", tz=UTC),
-            # National Holiday on Sunday, Mar 25th
-            pd.Timestamp("2018-03-23", tz=UTC),
-            pd.Timestamp("2018-03-26", tz=UTC),
-            # Labour Day on Sunday, May 1st
-            pd.Timestamp("2011-04-29", tz=UTC),
-            pd.Timestamp("2011-05-02", tz=UTC),
-            # Assumption Day on Saturday, Aug 15th
-            pd.Timestamp("2015-08-14", tz=UTC),
-            pd.Timestamp("2015-08-17", tz=UTC),
-            # National Holiday on Saturday, Oct 28
-            pd.Timestamp("2015-10-27", tz=UTC),
-            pd.Timestamp("2015-10-30", tz=UTC),
-            # Christmas Eve on a Sunday
-            #   Note: 25th, 26th both holidays
-            pd.Timestamp("2017-12-22", tz=UTC),
-            pd.Timestamp("2017-12-27", tz=UTC),
-            # Christmas on a Sunday
-            #   Note: 26th a holiday
-            pd.Timestamp("2016-12-23", tz=UTC),
-            pd.Timestamp("2016-12-27", tz=UTC),
-            # 2nd Day of Christmas on Saturday, Dec 26
-            #   Note: 25th, 24th both holidays
-            pd.Timestamp("2015-12-23", tz=UTC),
-            pd.Timestamp("2015-12-28", tz=UTC),
-        ]
-
-        for session_label in expected_sessions:
-            self.assertIn(session_label, all_sessions)
-
-    def test_orthodox_easter(self):
-        """
-        The Athens Stock Exchange observes Orthodox (or Eastern) Easter,
-        as well as Western Easter.  All holidays that are tethered to
-        Easter (i.e. Whit Monday, Good Friday, etc.), are relative to
-        Orthodox Easter.  This test checks that Orthodox Easter and all
-        related holidays are correct.
-        """
-        all_sessions = self.calendar.all_sessions
-
-        expected_holidays = [
+    @pytest.fixture(scope="class")
+    def regular_holidays_sample(self):
+        yield [
+            # 2019
+            "2019-01-01",  # New Year's Day
+            "2017-01-06",  # Epiphany
+            "2019-03-11",  # Orthodox Ash Monday
+            "2019-03-25",  # National Holiday
+            "2019-04-19",  # Good Friday
+            "2019-04-22",  # Easter Monday
+            "2019-04-26",  # Orthodox Good Friday
+            "2019-04-29",  # Orthodox Easter Monday
+            "2019-05-01",  # Labour Day
+            "2019-06-17",  # Orthodox Whit Monday
+            "2019-08-15",  # Assumption Day
+            "2019-10-28",  # National Holiday
+            "2019-12-24",  # Christmas Eve
+            "2019-12-25",  # Christmas Day
+            "2019-12-26",  # Second Day of Christmas
+            # The Athens Stock Exchange observes Orthodox (or Eastern) Easter,
+            # as well as Western Easter.  All holidays that are tethered to
+            # Easter (i.e. Whit Monday, Good Friday, etc.), are relative to
+            # Orthodox Easter. Following tests that Orthodox Easter and all
+            # related holidays are correct.
             # Some Orthodox Easter dates
-            pd.Timestamp("2005-05-01", tz=UTC),
-            pd.Timestamp("2006-04-23", tz=UTC),
-            pd.Timestamp("2009-04-19", tz=UTC),
-            pd.Timestamp("2013-05-05", tz=UTC),
-            pd.Timestamp("2015-04-12", tz=UTC),
-            pd.Timestamp("2018-04-08", tz=UTC),
+            "2005-05-01",
+            "2006-04-23",
+            "2009-04-19",
+            "2013-05-05",
+            "2015-04-12",
+            "2018-04-08",
             # Some Orthodox Good Friday dates
-            pd.Timestamp("2002-05-03", tz=UTC),
-            pd.Timestamp("2005-04-29", tz=UTC),
-            pd.Timestamp("2008-04-25", tz=UTC),
-            pd.Timestamp("2009-04-17", tz=UTC),
-            pd.Timestamp("2016-04-29", tz=UTC),
-            pd.Timestamp("2017-04-14", tz=UTC),
+            "2002-05-03",
+            "2005-04-29",
+            "2008-04-25",
+            "2009-04-17",
+            "2016-04-29",
+            "2017-04-14",
             # Some Orthodox Whit Monday dates
-            pd.Timestamp("2002-06-24", tz=UTC),
-            pd.Timestamp("2005-06-20", tz=UTC),
-            pd.Timestamp("2006-06-12", tz=UTC),
-            pd.Timestamp("2008-06-16", tz=UTC),
-            pd.Timestamp("2013-06-24", tz=UTC),
-            pd.Timestamp("2016-06-20", tz=UTC),
+            "2002-06-24",
+            "2005-06-20",
+            "2006-06-12",
+            "2008-06-16",
+            "2013-06-24",
+            "2016-06-20",
             # Some Orthodox Ash Monday dates
-            pd.Timestamp("2002-03-18", tz=UTC),
-            pd.Timestamp("2005-03-14", tz=UTC),
-            pd.Timestamp("2007-02-19", tz=UTC),
-            pd.Timestamp("2011-03-07", tz=UTC),
-            pd.Timestamp("2014-03-03", tz=UTC),
-            pd.Timestamp("2018-02-19", tz=UTC),
+            "2002-03-18",
+            "2005-03-14",
+            "2007-02-19",
+            "2011-03-07",
+            "2014-03-03",
+            "2018-02-19",
         ]
 
-        for holiday_label in expected_holidays:
-            self.assertNotIn(holiday_label, all_sessions)
+    @pytest.fixture(scope="class")
+    def adhoc_holidays_sample(self):
+        adhocs = [
+            "2002-05-07",  # Market Holiday
+            "2004-08-13",  # Assumption Day makeup
+            "2008-03-04",  # Worker strikes
+            "2008-03-05",  # Worker strikes
+            "2013-05-07",  # May Day strikes
+            "2014-12-31",  # New Year's Eve
+            "2016-05-03",  # Labour Day makeup
+        ]
+        # 2015 Greek debt crisis closed markets for an extended period.
+        # Following ensures there are no sessions over this time.
+        crisis_dates = pd.date_range("2015-06-29", "2015-07-31")
+        yield adhocs + crisis_dates.strftime("%Y-%m-%d").to_list()
 
-    def test_debt_crisis_closure(self):
-        """
-        In 2015, the debt crisis in Greece closed the markets for about
-        a month.  This test makes sure there were no trading days during
-        that time.
-        """
-        all_sessions = self.calendar.all_sessions
-        closed_dates = pd.date_range("2015-06-29", "2015-07-31")
-
-        for date in closed_dates:
-            self.assertNotIn(date, all_sessions)
-
-    def test_adhoc_holidays(self):
-        all_sessions = self.calendar.all_sessions
-
-        expected_holidays = [
-            pd.Timestamp("2002-05-07", tz=UTC),  # Market Holiday
-            pd.Timestamp("2004-08-13", tz=UTC),  # Assumption Day makeup
-            pd.Timestamp("2008-03-04", tz=UTC),  # Worker strikes
-            pd.Timestamp("2008-03-05", tz=UTC),  # Worker strikes
-            pd.Timestamp("2013-05-07", tz=UTC),  # May Day strikes
-            pd.Timestamp("2014-12-31", tz=UTC),  # New Year's Eve
-            pd.Timestamp("2016-05-03", tz=UTC),  # Labour Day makeup
+    @pytest.fixture(scope="class")
+    def sessions_sample(self):
+        yield [
+            # Holidays NOT made up despite falling on weekend. Following ensures
+            # surrounding days are not holidays.
+            # New Years Day on Sunday, Jan 1st
+            "2011-12-30",
+            "2012-01-02",
+            # Epiphany on Sunday, Jan 6th
+            "2019-01-04",
+            "2019-01-07",
+            # National Holiday on Sunday, Mar 25th
+            "2018-03-23",
+            "2018-03-26",
+            # Labour Day on Sunday, May 1st
+            "2011-04-29",
+            "2011-05-02",
+            # Assumption Day on Saturday, Aug 15th
+            "2015-08-14",
+            "2015-08-17",
+            # National Holiday on Saturday, Oct 28
+            "2015-10-27",
+            "2015-10-30",
+            # Christmas Eve on a Sunday. NB 25th and 26th both holidays.
+            "2017-12-22",
+            "2017-12-27",
+            # Christmas on a Sunday. NB 26th a holiday.
+            "2016-12-23",
+            "2016-12-27",
+            # 2nd Day of Christmas on Saturday, Dec 26th. NB 25th, 24th both holidays.
+            "2015-12-23",
+            "2015-12-28",
         ]
 
-        for holiday_label in expected_holidays:
-            self.assertNotIn(holiday_label, all_sessions)
+    # Calendar-specific tests
 
-    def test_close_time_change(self):
+    def test_close_time_change(self, default_calendar):
         """
         On Sept 29, 2008, the ASEX decided to push its close time back
         from 5:00PM to 5:20PM to close the time gap with Wall Street.
         """
-        self.assertEqual(
-            self.calendar.session_close(pd.Timestamp("2006-09-29", tz=UTC)),
-            pd.Timestamp("2006-09-29 17:00", tz="Europe/Athens"),
-        )
-        self.assertEqual(
-            self.calendar.session_close(pd.Timestamp("2008-09-26", tz=UTC)),
-            pd.Timestamp("2008-09-26 17:00", tz="Europe/Athens"),
-        )
-        self.assertEqual(
-            self.calendar.session_close(pd.Timestamp("2008-09-29", tz=UTC)),
-            pd.Timestamp("2008-09-29 17:20", tz="Europe/Athens"),
-        )
-        self.assertEqual(
-            self.calendar.session_close(pd.Timestamp("2008-09-30", tz=UTC)),
-            pd.Timestamp("2008-09-30 17:20", tz="Europe/Athens"),
-        )
+        cal = default_calendar
+        close_time = cal.closes["2006-09-29"].tz_localize("UTC")
+        assert close_time == pd.Timestamp("2006-09-29 17:00", tz="Europe/Athens")
+
+        close_time = cal.closes["2008-09-26"].tz_localize("UTC")
+        assert close_time == pd.Timestamp("2008-09-26 17:00", tz="Europe/Athens")
+
+        close_time = cal.closes["2008-09-29"].tz_localize("UTC")
+        assert close_time == pd.Timestamp("2008-09-29 17:20", tz="Europe/Athens")
+
+        close_time = cal.closes["2008-09-30"].tz_localize("UTC")
+        assert close_time == pd.Timestamp("2008-09-30 17:20", tz="Europe/Athens")

--- a/tests/test_bvmf_calendar.py
+++ b/tests/test_bvmf_calendar.py
@@ -1,100 +1,62 @@
-from unittest import TestCase
-
-import pandas as pd
-from pytz import UTC
+import pytest
 
 from exchange_calendars.exchange_calendar_bvmf import BVMFExchangeCalendar
+from .test_exchange_calendar import ExchangeCalendarTestBaseNew
 
-from .test_exchange_calendar import ExchangeCalendarTestBase
 
+class TestBVMFCalendar(ExchangeCalendarTestBaseNew):
+    @pytest.fixture(scope="class")
+    def calendar_cls(self):
+        yield BVMFExchangeCalendar
 
-class BVMFCalendarTestCase(ExchangeCalendarTestBase, TestCase):
+    @pytest.fixture(scope="class")
+    def max_session_hours(self):
+        yield 7
 
-    answer_key_filename = "bvmf"
-    calendar_class = BVMFExchangeCalendar
-
-    MINUTE_INDEX_TO_SESSION_LABELS_START = pd.Timestamp("2011-01-05", tz=UTC)
-    MINUTE_INDEX_TO_SESSION_LABELS_END = pd.Timestamp("2011-04-05", tz=UTC)
-
-    HAVE_EARLY_CLOSES = False
-
-    DAYLIGHT_SAVINGS_DATES = ["2017-02-17", "2017-10-16"]
-
-    # Open from 10am to 5pm
-    MAX_SESSION_HOURS = 7
-
-    def test_normal_year(self):
-        expected_holidays_2017 = [
-            pd.Timestamp("2017-01-25", tz=UTC),  # Sao Paolo City Anniversary
-            pd.Timestamp("2017-02-27", tz=UTC),  # Carnival
-            pd.Timestamp("2017-02-28", tz=UTC),  # Carnival
-            pd.Timestamp("2017-04-14", tz=UTC),  # Good Friday
-            pd.Timestamp("2017-04-21", tz=UTC),  # Tiradentes Day
-            pd.Timestamp("2017-05-01", tz=UTC),  # Labor Day
-            pd.Timestamp("2017-06-15", tz=UTC),  # Corpus Christi Day
-            pd.Timestamp("2017-09-07", tz=UTC),  # Independence Day
-            pd.Timestamp("2017-10-12", tz=UTC),  # Our Lady of Aparecida Day
-            pd.Timestamp("2017-11-02", tz=UTC),  # All Souls Day
-            pd.Timestamp("2017-11-15", tz=UTC),  # Proclamation of the
-            #  Republic Day
-            pd.Timestamp("2017-11-20", tz=UTC),  # Black Consciousness Day
-            pd.Timestamp("2017-12-25", tz=UTC),  # Christmas Day
-            pd.Timestamp("2017-12-29", tz=UTC),  # Day before New Years
+    @pytest.fixture(scope="class")
+    def regular_holidays_sample(self):
+        yield [
+            # 2017
+            "2017-01-25",  # Sao Paolo City Anniversary
+            "2017-02-27",  # Carnival
+            "2017-02-28",  # Carnival
+            "2017-04-14",  # Good Friday
+            "2017-04-21",  # Tiradentes Day
+            "2017-05-01",  # Labor Day
+            "2017-06-15",  # Corpus Christi Day
+            "2017-09-07",  # Independence Day
+            "2017-10-12",  # Our Lady of Aparecida Day
+            "2017-11-02",  # All Souls Day
+            "2017-11-15",  # Proclamation of the Republic Day
+            "2017-11-20",  # Black Consciousness Day
+            "2017-12-25",  # Christmas Day
+            "2017-12-29",  # Day before New Years
+            "2018-01-01",  # New Year's Day
+            # First occurrences
+            "1998-07-09",  # First occurrence of Constitutionalist Revolution holiday
+            "2006-11-20",  # Day of Black Awareness
+            # New Year's Eve
+            # if Jan 1 is Tuesday through Saturday, exchange closed the day before.
+            # if Jan 1 is Monday or Sunday, exchange closed the Friday before.
+            "2017-12-29",  # 2018: Jan 1 is Monday, so Friday 12/29 should be closed
+            "2016-12-30",  # 2017: Jan 1 is Sunday, so Friday 12/30 should be closed
+            "2010-12-31",  # 2011: Jan 1 is Saturday, so Friday 12/31 should be closed
+            "2013-12-31",  # 2014: Jan 1 is Wednesday, so Tuesday 12/31 should be closed
         ]
 
-        for session_label in expected_holidays_2017:
-            self.assertNotIn(session_label, self.calendar.all_sessions)
+    @pytest.fixture(scope="class")
+    def adhoc_holidays_sample(self):
+        yield ["2014-06-12"]  # world-cup
 
-        other_holidays = [
-            pd.Timestamp("2018-01-01", tz=UTC),  # New Year's Day
-            pd.Timestamp("2015-07-09", tz=UTC),  # Constitutional
-            #  Revolution Day
+    @pytest.fixture(scope="class")
+    def sessions_sample(self):
+        yield [
+            "1997-07-09",  # year prior to first Constitutionalist Revolution holiday
+            "2003-11-20",  # year prior to first Day of Black Awareness holiday
         ]
 
-        for session_label in other_holidays:
-            self.assertNotIn(session_label, self.calendar.all_sessions)
-
-    # FIXME: add back in later.
-    # def test_late_opens(self):
+    # FIXME: add back in later (NB late opens not included to calendar)
+    # @pytest.fixture(scope="class")
+    # def late_opens_sample(self):
     #     # Ash Wednesday, 46 days before Easter Sunday
-    #     late_opens = [
-    #         pd.Timestamp("2016-02-10", tz=UTC),
-    #         pd.Timestamp("2017-03-01", tz=UTC),
-    #         pd.Timestamp("2018-02-14", tz=UTC),
-    #     ]
-
-    #     for late_open_session_label in late_opens:
-    #         self.assertIn(
-    #             late_open_session_label,
-    #             self.calendar.late_opens,
-    #         )
-
-    def test_special_holidays(self):
-        # Constitutionalist Revolution started in 1998
-        self.assertNotIn(pd.Timestamp("1998-07-09", tz=UTC), self.calendar.all_sessions)
-
-        self.assertIn(pd.Timestamp("1997-07-09", tz=UTC), self.calendar.all_sessions)
-
-        # Day of Black Awareness started in 2004
-        self.assertNotIn(pd.Timestamp("2006-11-20", tz=UTC), self.calendar.all_sessions)
-
-        self.assertIn(pd.Timestamp("2003-11-20", tz=UTC), self.calendar.all_sessions)
-
-    def test_day_before_new_year(self):
-        # if Jan 1 is Tuesday through Saturday, we are closed the day before.
-        # if Jan 1 is Monday or Sunday, we are closed the Friday before.
-
-        # 2018: Jan 1 is Monday, so Friday 12/29 should be closed
-        self.assertFalse(self.calendar.is_session(pd.Timestamp("2017-12-29", tz=UTC)))
-
-        # 2017: Jan 1 is Sunday, so Friday 12/30 should be closed
-        self.assertFalse(self.calendar.is_session(pd.Timestamp("2016-12-30", tz=UTC)))
-
-        # 2011: Jan 1 is Saturday, so Friday 12/31 should be closed
-        self.assertFalse(self.calendar.is_session(pd.Timestamp("2010-12-31", tz=UTC)))
-
-        # 2014: Jan 1 is Wednesday, so Tuesday 12/31 should be closed
-        self.assertFalse(self.calendar.is_session(pd.Timestamp("2013-12-31", tz=UTC)))
-
-    def test_world_cup(self):
-        self.assertFalse(self.calendar.is_session(pd.Timestamp("2014-06-12", tz=UTC)))
+    #     yield ["2016-02-10", "2017-03-01", "2018-02-14"]

--- a/tests/test_cmes_calendar.py
+++ b/tests/test_cmes_calendar.py
@@ -1,51 +1,44 @@
-from __future__ import annotations
-from collections import abc
+import datetime
 
 import pytest
-import pandas as pd
-from pytz import UTC
 
 from exchange_calendars.exchange_calendar_cmes import CMESExchangeCalendar
-from exchange_calendars import ExchangeCalendar
-from .test_exchange_calendar import ExchangeCalendarTestBaseNew, Answers
+from .test_exchange_calendar import ExchangeCalendarTestBaseNew
 
 
 class TestCMESCalendar(ExchangeCalendarTestBaseNew):
     @pytest.fixture(scope="class", params=["left", "right"])
-    def all_calendars_with_answers(
-        self, request, calendars, answers
-    ) -> abc.Iterator[ExchangeCalendar, Answers]:
-        """Parameterized calendars and answers for each side."""
+    def all_calendars_with_answers(self, request, calendars, answers):
         yield (calendars[request.param], answers[request.param])
 
     @pytest.fixture(scope="class")
-    def calendar_cls(self) -> abc.Iterator[ExchangeCalendar]:
+    def calendar_cls(self):
         yield CMESExchangeCalendar
 
     @pytest.fixture(scope="class")
-    def max_session_hours(self) -> abc.Iterator[int | float]:
+    def max_session_hours(self):
         yield 24
 
-    # Additional tests
-
-    def test_2016_holidays(self, default_calendar):
+    @pytest.fixture(scope="class")
+    def regular_holidays_sample(self):
         # good friday, christmas, new years
-        for date in ["2016-03-25", "2016-12-26", "2016-01-02"]:
-            assert not default_calendar.is_session(
-                pd.Timestamp(date, tz=UTC), _parse=False
-            )
+        yield ["2016-03-25", "2016-12-26", "2016-01-02"]
 
-    def test_2016_early_closes(self, default_calendar):
-        cal = default_calendar
-        # TODO HERERE, WOULD THIS BE QUICKER IF COMPARED TWO INDICES?
-        for date in [
+    @pytest.fixture(scope="class")
+    def early_closes_sample(self):
+        yield [
             "2016-01-18",  # mlk day
             "2016-02-15",  # presidents
             "2016-05-30",  # mem day
             "2016-07-04",  # july 4
             "2016-09-05",  # labor day
             "2016-11-24",  # thanksgiving
-        ]:
-            dt = pd.Timestamp(date, tz=UTC)
-            assert dt in cal.early_closes
-            assert cal.closes[dt].tz_localize(UTC).tz_convert(cal.tz).hour == 12
+        ]
+
+    # Calendar-specific tests
+
+    def test_early_close_time(self, default_calendar, early_closes_sample):
+        cal = default_calendar
+        for early_close in early_closes_sample:
+            close_time = cal.closes[early_close].tz_localize("UTC").tz_convert(cal.tz)
+            assert close_time.time() == datetime.time(12, 0)

--- a/tests/test_iepa_calendar.py
+++ b/tests/test_iepa_calendar.py
@@ -1,55 +1,48 @@
-from unittest import TestCase
+import datetime
 
-import pandas as pd
-from pytz import UTC
+import pytest
 
 from exchange_calendars.exchange_calendar_iepa import IEPAExchangeCalendar
+from .test_exchange_calendar import ExchangeCalendarTestBaseNew
 
-from .test_exchange_calendar import ExchangeCalendarTestBase
 
+class TestIEPACalendar(ExchangeCalendarTestBaseNew):
+    @pytest.fixture(scope="class")
+    def calendar_cls(self):
+        yield IEPAExchangeCalendar
 
-class IEPACalendarTestCase(ExchangeCalendarTestBase, TestCase):
+    @pytest.fixture(scope="class")
+    def max_session_hours(self):
+        yield 22
 
-    answer_key_filename = "iepa"
-    calendar_class = IEPAExchangeCalendar
-    MAX_SESSION_HOURS = 22
+    @pytest.fixture(scope="class")
+    def regular_holidays_sample(self):
+        # new year's, good friday, christmas
+        yield ["2016-01-01", "2016-03-25", "2016-12-26"]
 
-    def test_hurricane_sandy_one_day(self):
-        self.assertFalse(self.calendar.is_session(pd.Timestamp("2012-10-29", tz=UTC)))
+    @pytest.fixture(scope="class")
+    def adhoc_holidays_sample(self):
+        yield ["2012-10-29"]  # hurricane sandy (day one)
 
-        # IEPA wasn't closed on day 2 of hurricane sandy
-        self.assertTrue(self.calendar.is_session(pd.Timestamp("2012-10-30", tz=UTC)))
+    @pytest.fixture(scope="class")
+    def sessions_sample(self):
+        yield ["2012-10-30"]  # hurricane sandy day two - exchange open
 
-    def test_2016_holidays(self):
-        # 2016 holidays:
-        # new years: 2016-01-01
-        # good friday: 2016-03-25
-        # christmas (observed): 2016-12-26
+    @pytest.fixture(scope="class")
+    def early_closes_sample(self):
+        yield [
+            "2016-01-18",  # mlk
+            "2016-02-15",  # presidents
+            "2016-05-30",  # mem day
+            "2016-07-04",  # independence day
+            "2016-09-05",  # labor
+            "2016-11-24",  # thanksgiving
+        ]
 
-        for date in ["2016-01-01", "2016-03-25", "2016-12-26"]:
-            self.assertFalse(self.calendar.is_session(pd.Timestamp(date, tz=UTC)))
+    # Calendar-specific tests
 
-    def test_2016_early_closes(self):
-        # 2016 early closes
-        # mlk: 2016-01-18
-        # presidents: 2016-02-15
-        # mem day: 2016-05-30
-        # independence day: 2016-07-04
-        # labor: 2016-09-05
-        # thanksgiving: 2016-11-24
-        for date in [
-            "2016-01-18",
-            "2016-02-15",
-            "2016-05-30",
-            "2016-07-04",
-            "2016-09-05",
-            "2016-11-24",
-        ]:
-            dt = pd.Timestamp(date, tz=UTC)
-            self.assertTrue(dt in self.calendar.early_closes)
-
-            market_close = self.calendar.schedule.loc[dt].market_close
-            self.assertEqual(
-                13,  # all IEPA early closes are 1 pm local
-                market_close.tz_localize(UTC).tz_convert(self.calendar.tz).hour,
-            )
+    def test_early_close_time(self, default_calendar, early_closes_sample):
+        cal = default_calendar
+        for early_close in early_closes_sample:
+            local_close = cal.closes[early_close].tz_localize("UTC").tz_convert(cal.tz)
+            assert local_close.time() == datetime.time(13, 0)

--- a/tests/test_weekday_calendar.py
+++ b/tests/test_weekday_calendar.py
@@ -1,33 +1,26 @@
-from __future__ import annotations
-from collections import abc
-
 import pytest
 import pandas as pd
 import pandas.testing as tm
 from pytz import UTC
 
 from exchange_calendars.weekday_calendar import WeekdayCalendar
-from exchange_calendars import ExchangeCalendar
-from .test_exchange_calendar import ExchangeCalendarTestBaseNew, Answers
+from .test_exchange_calendar import ExchangeCalendarTestBaseNew
 
 
 class TestWeekdayCalendar(ExchangeCalendarTestBaseNew):
     @pytest.fixture(scope="class", params=["left", "right"])
-    def all_calendars_with_answers(
-        self, request, calendars, answers
-    ) -> abc.Iterator[ExchangeCalendar, Answers]:
-        """Parameterized calendars and answers for each side."""
+    def all_calendars_with_answers(self, request, calendars, answers):
         yield (calendars[request.param], answers[request.param])
 
     @pytest.fixture(scope="class")
-    def calendar_cls(self) -> abc.Iterator[ExchangeCalendar]:
+    def calendar_cls(self):
         yield WeekdayCalendar
 
     @pytest.fixture(scope="class")
-    def max_session_hours(self) -> abc.Iterator[int | float]:
+    def max_session_hours(self):
         yield 24
 
-    # Additional tests
+    # Calendar-specific tests
 
     def test_open_every_weekday(self, default_calendar_with_answers):
         cal, ans = default_calendar_with_answers

--- a/tests/test_xlon_calendar.py
+++ b/tests/test_xlon_calendar.py
@@ -1,76 +1,57 @@
-from __future__ import annotations
-from collections import abc
-
 import pytest
 
 from exchange_calendars.exchange_calendar_xlon import XLONExchangeCalendar
 from .test_exchange_calendar import ExchangeCalendarTestBaseNew
-from .test_utils import T
 
 
 class TestXLONCalendar(ExchangeCalendarTestBaseNew):
     @pytest.fixture(scope="class")
-    def calendar_cls(self) -> abc.Iterator[XLONExchangeCalendar]:
+    def calendar_cls(self):
         yield XLONExchangeCalendar
 
     @pytest.fixture(scope="class")
-    def max_session_hours(self) -> abc.Iterator[int | float]:
+    def max_session_hours(self):
         yield 8.5
 
-    # Additional tests
-
-    def test_2012(self, default_calendar):
-        cal = default_calendar
-        expected_holidays_2012 = [
-            T("2012-01-02"),  # New Year's observed
-            T("2012-04-06"),  # Good Friday
-            T("2012-04-09"),  # Easter Monday
-            T("2012-05-07"),  # May Day
-            T("2012-06-04"),  # Spring Bank Holiday
-            T("2012-08-27"),  # Summer Bank Holiday
-            T("2012-12-25"),  # Christmas
-            T("2012-12-26"),  # Boxing Day
+    @pytest.fixture(scope="class")
+    def regular_holidays_sample(self):
+        yield [
+            # 2012
+            "2012-01-02",  # New Year's observed
+            "2012-04-06",  # Good Friday
+            "2012-04-09",  # Easter Monday
+            "2012-05-07",  # May Day
+            "2012-06-04",  # Spring Bank Holiday
+            "2012-08-27",  # Summer Bank Holiday
+            "2012-12-25",  # Christmas
+            "2012-12-26",  # Boxing Day
         ]
 
-        for session in expected_holidays_2012:
-            assert session not in cal.all_sessions
-
-        early_closes_2012 = [
-            T("2012-12-24"),  # Christmas Eve
-            T("2012-12-31"),  # New Year's Eve
+    @pytest.fixture(scope="class")
+    def adhoc_holidays_sample(self):
+        yield [
+            "2002-06-03",  # Spring Bank 2002
+            "2002-06-04",  # Golden Jubilee
+            "2011-04-29",  # Royal Wedding
+            "2012-06-04",  # Spring Bank 2012
+            "2012-06-05",  # Diamond Jubilee
+            "2020-05-08",  # VE Day
         ]
 
-        for session in early_closes_2012:
-            assert session in cal.early_closes
-
-    def test_special_holidays(self, default_calendar):
-        cal = default_calendar
-        special_holidays = [
-            T("2002-06-03"),  # Spring Bank 2002
-            T("2002-06-04"),  # Golden Jubilee
-            T("2011-04-29"),  # Royal Wedding
-            T("2012-06-04"),  # Spring Bank 2012
-            T("2012-06-05"),  # Diamond Jubilee
-            T("2020-05-08"),  # VE Day
-        ]
-
-        for holiday in special_holidays:
-            assert holiday not in cal.all_sessions
-
-    def test_special_non_holidays(self, default_calendar):
+    @pytest.fixture(scope="class")
+    def sessions_sample(self):
         # May Bank Holiday was instead observed on VE Day in 2020.
-        assert T("2020-05-04") in default_calendar.all_sessions
+        yield ["2020-05-04"]
 
-    def test_specific_early_closes(self, default_calendar):
-        early_closes = [
-            # In Dec 2010, Christmas Eve and NYE are on Friday.
-            T("2010-12-24"),
-            T("2010-12-31"),
-            # In Dec 2011, Christmas Eve and NYE were both on a Saturday,
+    @pytest.fixture(scope="class")
+    def early_closes_sample(self):
+        yield [
+            "2012-12-24",  # Christmas Eve
+            "2012-12-31",  # New Year's Eve
+            "2010-12-24",  # Christmas Eve
+            "2010-12-31",  # New Year's Eve
+            # In Dec 2011, Christmas Eve and NYE are both on a Saturday,
             # so preceding Fridays (the 23rd and 30th) are early closes.
-            T("2011-12-23"),
-            T("2011-12-30"),
+            "2011-12-23",
+            "2011-12-30",
         ]
-
-        for session in early_closes:
-            assert session in default_calendar.early_closes


### PR DESCRIPTION
Migrates following test modules to new test base:
- `test_aixk_calendar.py`
- `test_asex_calendar.py`
- `test_bvmf_calendar.py`
- `test_iepa_calendar.py`
- `test_xasx_calendar.py`

Adds to `ExchangeCalendarTestBaseNew` tests and associated fixtures
to offer a common implementation for common calendar-specific tests.
Tests added:-
- `test_regular_holidays_sample`
- `test_adhoc_holidays_sample`
- `test_sessions_sample`
- `test_late_opens_sample`
- `test_early_closes_sample`

Revises following previously migrated modules by adding fixtures to
accommodate common implementation of new calendar-specific tests:
- `test_always_open.py`
- `test_weekday_calendar.py`
- `test_xlon_calendar.py`
- `test_xhkg_calendar.py`
- `test_cmes_calendar.py`

Adds `test_testbase_integrity` to ensure a subclass does not override
a reserved fixture.