### PR TITLE
Revise / Extend `ExchangeCalendarTestBaseNew`

### DIFF
--- a/tests/test_aixk_calendar.py
+++ b/tests/test_aixk_calendar.py
@@ -37,6 +37,7 @@ class TestAIXKCalendar(ExchangeCalendarTestBaseNew):
             "2021-12-01",  # First President Day
             "2021-12-16",  # Independence Day
             "2021-12-17",  # Independence Day Holiday
+            #
             # Holiday's made up when fall on weekend.
             # Last day of Nauryz on Saturday, 23th
             "2019-03-21",

--- a/tests/test_asex_calendar.py
+++ b/tests/test_asex_calendar.py
@@ -34,6 +34,7 @@ class TestASEXCalendar(ExchangeCalendarTestBaseNew):
             "2019-12-24",  # Christmas Eve
             "2019-12-25",  # Christmas Day
             "2019-12-26",  # Second Day of Christmas
+            #
             # The Athens Stock Exchange observes Orthodox (or Eastern) Easter,
             # as well as Western Easter.  All holidays that are tethered to
             # Easter (i.e. Whit Monday, Good Friday, etc.), are relative to
@@ -86,7 +87,7 @@ class TestASEXCalendar(ExchangeCalendarTestBaseNew):
         yield adhocs + crisis_dates.strftime("%Y-%m-%d").to_list()
 
     @pytest.fixture(scope="class")
-    def sessions_sample(self):
+    def non_holidays_sample(self):
         yield [
             # Holidays NOT made up despite falling on weekend. Following ensures
             # surrounding days are not holidays.

--- a/tests/test_bvmf_calendar.py
+++ b/tests/test_bvmf_calendar.py
@@ -32,9 +32,11 @@ class TestBVMFCalendar(ExchangeCalendarTestBaseNew):
             "2017-12-25",  # Christmas Day
             "2017-12-29",  # Day before New Years
             "2018-01-01",  # New Year's Day
+            #
             # First occurrences
             "1998-07-09",  # First occurrence of Constitutionalist Revolution holiday
             "2006-11-20",  # Day of Black Awareness
+            #
             # New Year's Eve
             # if Jan 1 is Tuesday through Saturday, exchange closed the day before.
             # if Jan 1 is Monday or Sunday, exchange closed the Friday before.
@@ -49,7 +51,7 @@ class TestBVMFCalendar(ExchangeCalendarTestBaseNew):
         yield ["2014-06-12"]  # world-cup
 
     @pytest.fixture(scope="class")
-    def sessions_sample(self):
+    def non_holidays_sample(self):
         yield [
             "1997-07-09",  # year prior to first Constitutionalist Revolution holiday
             "2003-11-20",  # year prior to first Day of Black Awareness holiday

--- a/tests/test_cmes_calendar.py
+++ b/tests/test_cmes_calendar.py
@@ -1,6 +1,5 @@
-import datetime
-
 import pytest
+import pandas as pd
 
 from exchange_calendars.exchange_calendar_cmes import CMESExchangeCalendar
 from .test_exchange_calendar import ExchangeCalendarTestBaseNew
@@ -35,10 +34,6 @@ class TestCMESCalendar(ExchangeCalendarTestBaseNew):
             "2016-11-24",  # thanksgiving
         ]
 
-    # Calendar-specific tests
-
-    def test_early_close_time(self, default_calendar, early_closes_sample):
-        cal = default_calendar
-        for early_close in early_closes_sample:
-            close_time = cal.closes[early_close].tz_localize("UTC").tz_convert(cal.tz)
-            assert close_time.time() == datetime.time(12, 0)
+    @pytest.fixture(scope="class")
+    def early_closes_sample_time(self):
+        yield pd.Timedelta(12, "H")

--- a/tests/test_iepa_calendar.py
+++ b/tests/test_iepa_calendar.py
@@ -1,6 +1,5 @@
-import datetime
-
 import pytest
+import pandas as pd
 
 from exchange_calendars.exchange_calendar_iepa import IEPAExchangeCalendar
 from .test_exchange_calendar import ExchangeCalendarTestBaseNew
@@ -25,7 +24,7 @@ class TestIEPACalendar(ExchangeCalendarTestBaseNew):
         yield ["2012-10-29"]  # hurricane sandy (day one)
 
     @pytest.fixture(scope="class")
-    def sessions_sample(self):
+    def non_holidays_sample(self):
         yield ["2012-10-30"]  # hurricane sandy day two - exchange open
 
     @pytest.fixture(scope="class")
@@ -39,10 +38,6 @@ class TestIEPACalendar(ExchangeCalendarTestBaseNew):
             "2016-11-24",  # thanksgiving
         ]
 
-    # Calendar-specific tests
-
-    def test_early_close_time(self, default_calendar, early_closes_sample):
-        cal = default_calendar
-        for early_close in early_closes_sample:
-            local_close = cal.closes[early_close].tz_localize("UTC").tz_convert(cal.tz)
-            assert local_close.time() == datetime.time(13, 0)
+    @pytest.fixture(scope="class")
+    def early_closes_sample_time(self):
+        yield pd.Timedelta(13, "H")

--- a/tests/test_xasx_calendar.py
+++ b/tests/test_xasx_calendar.py
@@ -1,6 +1,5 @@
-import datetime
-
 import pytest
+import pandas as pd
 
 from exchange_calendars.exchange_calendar_xasx import XASXExchangeCalendar
 from .test_exchange_calendar import ExchangeCalendarTestBaseNew
@@ -27,6 +26,7 @@ class TestXASXCalendar(ExchangeCalendarTestBaseNew):
             "2018-06-11",  # Queen's Birthday
             "2018-12-25",  # Christmas
             "2018-12-26",  # Boxing Day
+            #
             # Holidays made up when fall on weekend.
             # Anzac Day is observed on the following Monday only when falling
             # on a Sunday. In years where Anzac Day falls on a Saturday, there
@@ -47,7 +47,7 @@ class TestXASXCalendar(ExchangeCalendarTestBaseNew):
         ]
 
     @pytest.fixture(scope="class")
-    def sessions_sample(self):
+    def non_holidays_sample(self):
         # Anzac Day on a Saturday, does not have a make-up (prior to 2010).
         yield ["2015-04-27", "2004-04-26"]
 
@@ -68,15 +68,15 @@ class TestXASXCalendar(ExchangeCalendarTestBaseNew):
             "2016-12-30",
         ]
 
-    # Calendar-specific tests
+    @pytest.fixture(scope="class")
+    def early_closes_sample_time(self):
+        yield pd.Timedelta(hours=14, minutes=10)
 
-    def test_early_close_time(self, default_calendar, early_closes_sample):
-        cal = default_calendar
-        for early_close in early_closes_sample:
-            close_time = cal.closes[early_close].tz_localize("UTC").tz_convert(cal.tz)
-            assert close_time.time() == datetime.time(14, 10)
+    @pytest.fixture(scope="class")
+    def non_early_closes_sample(self):
+        # In 2009 the early close rules should not be in effect yet.
+        yield ["2009-12-24", "2009-12-31"]
 
-        # In 2009 the half day rules should not be in effect yet.
-        for full_day in ["2009-12-24", "2009-12-31"]:
-            close_time = cal.closes[full_day].tz_localize("UTC").tz_convert(cal.tz)
-            assert close_time.time() == datetime.time(16, 0)
+    @pytest.fixture(scope="class")
+    def non_early_closes_sample_time(self):
+        yield pd.Timedelta(16, "H")


### PR DESCRIPTION
(@gerrymanoim, this comment explains why for all calendars some new calendar-specific tests will be showing up as skipped.)

This PR extends work started by #91 to offer a **common implementation of common calendar-specific tests**...

Fixtures dedicated to these tests are defined on the base and can be optionally overriden by a subclass. If such a fixture is overriden then an associated test is executed with input as yielded by the fixture.
Fixture  |  Test
-|-
`regular_holidays_sample`  |  `test_regular_holidays_sample`
`adhoc_holidays_sample`  |  `test_adhoc_holidays_sample`
`non_holidays_sample`  |  `test_non_holidays_sample` 
`late_opens_sample`  |  `test_late_opens_sample`
`early_closes_sample`  |  `test_early_closes_sample`
`early_closes_sample_time`  |  `test_early_closes_sample_time`
`non_early_closes_sample`  |  `test_non_early_closes_sample`
`non_early_closes_sample_time`  |  `test_non_early_closes_sample_time`

For example, if the subclass overrides the `regular_holidays_sample` fixture then the `test_regular_holidays_sample` test checks that each date yielded by the fixture does not represent a calendar session. See the docs for further info on any fixture / test.

These tests were previously implemented inconsistently, both in terms of the subclasses that accommodated them (only some did for only some tests) and how they were implemented. Having these tests defined on the base makes the implementation consistent, although a test is only executed for (i.e. fixture overriden on) a subclass that previously provided that test in some form. Where a subclass does not override a fixture the associated test is skipped.

Occassionally a test is skipped because it is not relevant to a subclass (for example, "24/7" does not have holidays, some calendars do not have early closes etc). More often these tests are skipped because the subclass did not previously provide for such a test, although it could have. For this reason such 'missing tests' are skipped rather than allowed to pass siliently.

Commit message:

Revises and extends `ExchangeCalendarTestBaseNew` tests and associated
fixtures that offer a common implementation for common calendar-specific
tests. Skips these tests where subclass does not override associated
fixture. Tests (and associated fixtures) added:-
- `test_early_closes_sample_time`
- `test_non_early_closes_sample`
- `test_non_early_closes_sample_time`

Also:
- `test_sessions_sample` renamed `test_non_holidays_sample` and associated fixture renamed as `non_holidays_sample`.

Previously migrated calendar test modules revised to accommodate changes.