### PR TITLE
XLON: Add Platinum Jubilee Day and move Spring Bank Holiday.

### DIFF
--- a/exchange_calendars/exchange_calendar_xlon.py
+++ b/exchange_calendars/exchange_calendar_xlon.py
@@ -75,9 +75,10 @@ MayBank_post_2020 = Holiday(
 )
 
 
-# Spring bank holiday has two exceptions based on the Golden & Diamond Jubilee
+# Spring bank holiday has three exceptions based on the Golden, Diamond & Platinum Jubilee
 # 2002-05-27 Spring bank holiday removed for Golden Jubilee
 # 2012-05-28 Spring bank holiday removed for Diamond Jubilee
+# 2022-05-30 Spring bank holiday moved to 2022-06-02 to be adjacent to the Platinum Jubilee day 2022-06-03
 
 # Spring bank holiday
 SpringBank_pre_2002 = Holiday(
@@ -97,12 +98,21 @@ SpringBank_post_2002_pre_2012 = Holiday(
     end_date=pd.Timestamp("2011-12-31"),
 )
 
-SpringBank_post_2012 = Holiday(
+SpringBank_post_2012_pre_2022 = Holiday(
     "Spring Bank Holiday",
     month=5,
     day=31,
     offset=DateOffset(weekday=MO(-1)),
     start_date=pd.Timestamp("2013-01-01"),
+    end_date=pd.Timestamp("2021-12-31"),
+)
+
+SpringBank_post_2022 = Holiday(
+    "Spring Bank Holiday",
+    month=5,
+    day=31,
+    offset=DateOffset(weekday=MO(-1)),
+    start_date=pd.Timestamp("2023-01-01"),
 )
 
 # Summer bank holiday
@@ -196,7 +206,8 @@ class XLONExchangeCalendar(ExchangeCalendar):
                 MayBank_post_2020,
                 SpringBank_pre_2002,
                 SpringBank_post_2002_pre_2012,
-                SpringBank_post_2012,
+                SpringBank_post_2012_pre_2022,
+                SpringBank_post_2022,
                 SummerBank,
                 Christmas,
                 WeekendChristmas,
@@ -220,6 +231,9 @@ class XLONExchangeCalendar(ExchangeCalendar):
             # Diamond Jubilee
             pd.Timestamp("2012-06-04"),
             pd.Timestamp("2012-06-05"),
+            # Platinum Jubilee (moved Spring bank holiday followed by Jubilee day)
+            pd.Timestamp("2022-06-02"),
+            pd.Timestamp("2022-06-03"),
             # Royal Weddings
             # Wedding Day of Princess Anne and Mark Phillips
             pd.Timestamp("1973-11-14"),


### PR DESCRIPTION
It seems that owing to the celebration of the Queen's Platinum Jubilee in 2022, a new ad-hoc holiday has been added on 2022-06-03. Also, the Spring Bank Holiday - which would have been on 2022-05-30 - seems to have been moved to 2022-06-02 to be adjacent to the Jubilee day and make for a nice long weekend.

This PR adds those changes. Hope you can consider it.