### PR TITLE
TST: bump pandas and fix resulting test failures

### DIFF
--- a/etc/requirements_locked.txt
+++ b/etc/requirements_locked.txt
@@ -4,51 +4,53 @@
 #
 #    pip-compile --output-file=requirements_locked.txt requirements.in requirements_dev.in
 #
-attrs==21.2.0
-    # via pytest
-click==8.0.1
+attrs==21.4.0
+    # via
+    #   hypothesis
+    #   pytest
+click==8.0.3
     # via pip-tools
 execnet==1.9.0
     # via pytest-xdist
-flake8==3.9.2
+flake8==4.0.1
+    # via -r requirements_dev.in
+hypothesis==6.36.2
     # via -r requirements_dev.in
 iniconfig==1.1.1
     # via pytest
-hypothesis==6.23.2
-    # 2021-10-15 - manually added.
+korean-lunar-calendar==0.2.1
+    # via -r requirements.in
 mccabe==0.6.1
     # via flake8
-numpy==1.21.0
+numpy==1.22.2
     # via
     #   -r requirements.in
     #   pandas
-packaging==21.0
+packaging==21.3
     # via pytest
-pandas==1.3.0
+pandas==1.4.1
     # via -r requirements.in
-# parameterized==0.8.1  # 2021-10-15 - manually removed.
-    # via -r requirements_dev.in
-pep517==0.10.0
+pep517==0.12.0
     # via pip-tools
-pip-tools==6.2.0
+pip-tools==6.5.1
     # via -r requirements_dev.in
-pluggy==0.13.1
+pluggy==1.0.0
     # via pytest
-py==1.10.0
+py==1.11.0
     # via
     #   pytest
     #   pytest-forked
 py-cpuinfo==8.0.0
     # via pytest-benchmark
-pycodestyle==2.7.0
+pycodestyle==2.8.0
     # via flake8
-pyflakes==2.3.1
+pyflakes==2.4.0
     # via flake8
 pyluach==1.3.0
     # via -r requirements.in
-pyparsing==2.4.7
+pyparsing==3.0.7
     # via packaging
-pytest==6.2.4
+pytest==7.0.1
     # via
     #   -r requirements_dev.in
     #   pytest-benchmark
@@ -56,29 +58,29 @@ pytest==6.2.4
     #   pytest-xdist
 pytest-benchmark==3.4.1
     # via -r requirements_dev.in
-pytest-forked==1.3.0
+pytest-forked==1.4.0
     # via pytest-xdist
-pytest-xdist==2.3.0
+pytest-xdist==2.5.0
     # via -r requirements_dev.in
-python-dateutil==2.8.1
+python-dateutil==2.8.2
     # via
     #   -r requirements.in
     #   pandas
-pytz==2021.1
+pytz==2021.3
     # via
     #   -r requirements.in
     #   pandas
 six==1.16.0
     # via python-dateutil
 sortedcontainers==2.4.0
-    # 2021-10-15 - manually added, dependency of hypothesis
-toml==0.10.2
+    # via hypothesis
+tomli==2.0.1
     # via
     #   pep517
     #   pytest
-toolz==0.11.1
+toolz==0.11.2
     # via -r requirements.in
-wheel==0.36.2
+wheel==0.37.1
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/exchange_calendars/pandas_extensions/offsets.py
+++ b/exchange_calendars/pandas_extensions/offsets.py
@@ -142,7 +142,7 @@ class CompositeCustomBusinessDay(CustomBusinessDay):
         )
 
     @apply_wraps
-    def apply(self, other):
+    def _apply(self, other):
         if isinstance(other, datetime):
             moved = 0
             remaining = self.n - moved
@@ -169,6 +169,9 @@ class CompositeCustomBusinessDay(CustomBusinessDay):
             return result
         else:
             return super().apply(other)
+
+    # backwards compat
+    apply = _apply
 
     def is_on_offset(self, dt):
         if self.normalize and not _is_normalized(dt):

--- a/exchange_calendars/tase_holidays.py
+++ b/exchange_calendars/tase_holidays.py
@@ -222,7 +222,7 @@ class _HolidayOffset(Easter):
         pass
 
     @apply_wraps
-    def apply(self, other):
+    def _apply(self, other):
         current = self.holiday(other.year).to_pydate()
         current = datetime(current.year, current.month, current.day)
         current = localize_pydatetime(current, other.tzinfo)
@@ -247,6 +247,9 @@ class _HolidayOffset(Easter):
             other.microsecond,
         )
         return new
+
+    # backwards compat
+    apply = _apply
 
     def is_on_offset(self, dt):
         if self.normalize and not _is_normalized(dt):


### PR DESCRIPTION
Turns out the windows CI doesn't respect `PIP_CONSTRAINT` so it started failing when pandas/numpy got updated. 

This bumps everything in requirements_locked.txt to the newest version and fixes the resulting test failures. 

Need to come up with a better dependabot based workflow for these. 