### PR TITLE
Attempt to fix Korean lunar calendar bug.

### DIFF
--- a/tests/test_xkrx_calendar.py
+++ b/tests/test_xkrx_calendar.py
@@ -1,5 +1,7 @@
-import pytest
+from datetime import date
+
 import pandas as pd
+import pytest
 
 from exchange_calendars.exchange_calendar_xkrx import XKRXExchangeCalendar
 from .test_exchange_calendar import ExchangeCalendarTestBase
@@ -126,3 +128,7 @@ class TestXKRXCalendar(ExchangeCalendarTestBase):
         # except the future holidays that are not precomputed yet
         bv = non_weekend_regular.index.isin(precomputed)
         assert bv.all(), f"missing holidays = \n{non_weekend_regular[~bv]}"
+
+    def test_feb_29_2022_in_lunar_calendar(self, default_calendar):
+        # This test asserts that the following does not throw an exception.
+        default_calendar.regular_holidays.holidays(date(2022, 3, 31), date(2022, 3, 31))


### PR DESCRIPTION
This PR addresses a bug in `exchange_calendars/pandas_extensions/korean_holiday.py`. You can see the bug by adding the following test case to `tests/test_xkrx_calendar.py`:
```python
def test_feb_29_2022_in_lunar_calendar(self, default_calendar):
    default_calendar.regular_holidays.holidays(date(2022, 3, 31), date(2022, 3, 31))
```
The underlying cause is that `korean_holiday.py` is trying to store lunar dates inside Gregorian date objects. 2022-03-31 (Gregorian) corresponds to 2022-02-29 (Korean Lunar), at least according to https://astro.kasi.re.kr/life/pageView/8 (with Google Translate). 2022-02-29 is not a valid Gregorian date, and so the operation fails. This PR widens the date range used in `_reference_dates` if necessary, and then filters out any extra holidays at the end.

As an aside, I've raised my concern about the Korean holiday generation code [before](https://github.com/gerrymanoim/exchange_calendars/issues/128), and I think that this bug highlights the inherent complexity that the code brings. I think that moving towards a hardcoded set of holidays is probably the right thing to do. 