### PR TITLE
Update ExchangeCalendar.trading_index

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ ecal XNYS 1 2020
 | market_break_starts_nanos | break_starts_nanos |
 | market_break_ends_nanos | break_ends_nanos |
 
-## What to expect in 4.0? (February/March 2022)
+## What to expect in 4.0? (April 2022)
 Major anticipated changes in 4.0 include the following (see the [path to 4.0](https://github.com/gerrymanoim/exchange_calendars/issues/61) for a fuller list):
 * Changes to the timezone of returned sessions and times (these changes are not yet set in stone - please have your say [here](https://github.com/gerrymanoim/exchange_calendars/issues/42)).
   * Schedule times to change from tz-naive to "UTC".

--- a/docs/tutorials/trading_index.ipynb
+++ b/docs/tutorials/trading_index.ipynb
@@ -13,12 +13,13 @@
    "source": [
     "This tutorial shows all the ins and outs of the calendars' `trading_index` method. (For other calendar methods see the [calendar_methods.ipynb](./calendar_methods.ipynb) tutorial.)\n",
     "\n",
-    "The [What does it do?](#What-does-it-do?) section shows basic usage. Each of the following sections then explore the method's arguments and options:\n",
+    "The [What does it do?](#What-does-it-do?) section explains basic usage. The following sections then explore the method's arguments and options:\n",
     "\n",
     "* [`intervals`](#intervals)\n",
     "* [`period`](#period)\n",
     "* [`closed`](#closed)\n",
-    "* [`force_close` and `force_break_close`](#force_close-and-force_break_close)\n",
+    "* [`force_close`, `force_break_close` and `force`](#force_close,-force_break_close-and-force)\n",
+    "* [`ignore_breaks`](#ignore_breaks)\n",
     "\n",
     "The final section covers [overlapping indices](#Overlapping-indices)."
    ]
@@ -210,7 +211,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "By passing `intervals` as False the index can be output as a `DatetimeIndex`, as shown above. Although, by default the index is output as an `IntervalIndex`."
+    "By passing `intervals` as False the index can be output as a `DatetimeIndex`, as shown above. Although by default the index is output as an `IntervalIndex`."
    ]
   },
   {
@@ -805,7 +806,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Hong Kong has a lunch break. The trading index covers the morning subsession starting with the open, and then the afternoon subsession starting with the break-end. The hour and a half represents the difference between the last indice of the morning subsession and the first indice of the afternoon subsession.\n",
+    "Hong Kong has a lunch break. The trading index covers the morning subsession starting with the open, and then the afternoon subsession starting with the break-end. The hour and a half represents the difference between the last indice of the morning subsession and the first indice of the afternoon subsession. (See [`ignore_breaks`](#ignore_breaks) to treat session as continuous.)\n",
     "\n",
     "Ok, fine, but why hasn't the index included indices for 04:00 or 08:00? Because, it's `closed` on the \"left\" (by default)..."
    ]
@@ -932,7 +933,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### `force_close` and `force_break_close`"
+    "### `force_close`, `force_break_close` and `force`"
    ]
   },
   {
@@ -1039,7 +1040,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Specifically, consider the last indice of the morning subsession against the break-start time."
+    "Specifically, consider the last indice of the morning subsession against the break-start time..."
    ]
   },
   {
@@ -1336,7 +1337,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "An obvious consequence of forcing the close is that any indice that's forced will have a shorter period length than `period`."
+    "If you are going to set both `force_close` and `force_break_close` to the same value then you're better off passing just the `force` convenience option. If passed, `force` sets both `force_close` and `force_break_close` (anything passed to either will be overriden)."
    ]
   },
   {
@@ -1346,13 +1347,113 @@
    "outputs": [
     {
      "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>left_side</th>\n",
+       "      <th>right_side</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>IntervalIndex</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>[2021-12-23 01:30:00, 2021-12-23 02:50:00)</th>\n",
+       "      <td>2021-12-23 01:30:00+00:00</td>\n",
+       "      <td>2021-12-23 02:50:00+00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>[2021-12-23 02:50:00, 2021-12-23 04:00:00)</th>\n",
+       "      <td>2021-12-23 02:50:00+00:00</td>\n",
+       "      <td>2021-12-23 04:00:00+00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>[2021-12-23 05:00:00, 2021-12-23 06:20:00)</th>\n",
+       "      <td>2021-12-23 05:00:00+00:00</td>\n",
+       "      <td>2021-12-23 06:20:00+00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>[2021-12-23 06:20:00, 2021-12-23 07:40:00)</th>\n",
+       "      <td>2021-12-23 06:20:00+00:00</td>\n",
+       "      <td>2021-12-23 07:40:00+00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>[2021-12-23 07:40:00, 2021-12-23 08:00:00)</th>\n",
+       "      <td>2021-12-23 07:40:00+00:00</td>\n",
+       "      <td>2021-12-23 08:00:00+00:00</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
       "text/plain": [
-       "TimedeltaIndex(['0 days 01:20:00', '0 days 01:10:00', '0 days 01:20:00',\n",
-       "                '0 days 01:20:00', '0 days 01:20:00'],\n",
-       "               dtype='timedelta64[ns]', freq=None)"
+       "                                                           left_side  \\\n",
+       "IntervalIndex                                                          \n",
+       "[2021-12-23 01:30:00, 2021-12-23 02:50:00) 2021-12-23 01:30:00+00:00   \n",
+       "[2021-12-23 02:50:00, 2021-12-23 04:00:00) 2021-12-23 02:50:00+00:00   \n",
+       "[2021-12-23 05:00:00, 2021-12-23 06:20:00) 2021-12-23 05:00:00+00:00   \n",
+       "[2021-12-23 06:20:00, 2021-12-23 07:40:00) 2021-12-23 06:20:00+00:00   \n",
+       "[2021-12-23 07:40:00, 2021-12-23 08:00:00) 2021-12-23 07:40:00+00:00   \n",
+       "\n",
+       "                                                          right_side  \n",
+       "IntervalIndex                                                         \n",
+       "[2021-12-23 01:30:00, 2021-12-23 02:50:00) 2021-12-23 02:50:00+00:00  \n",
+       "[2021-12-23 02:50:00, 2021-12-23 04:00:00) 2021-12-23 04:00:00+00:00  \n",
+       "[2021-12-23 05:00:00, 2021-12-23 06:20:00) 2021-12-23 06:20:00+00:00  \n",
+       "[2021-12-23 06:20:00, 2021-12-23 07:40:00) 2021-12-23 07:40:00+00:00  \n",
+       "[2021-12-23 07:40:00, 2021-12-23 08:00:00) 2021-12-23 08:00:00+00:00  "
       ]
      },
      "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "index = hkg.trading_index(start, start, \"80T\", force=True)\n",
+    "show_as_df(index)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "An obvious consequence of forcing the close is that any indice that's forced will have a shorter period length than `period`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "TimedeltaIndex(['0 days 01:20:00', '0 days 01:10:00', '0 days 01:20:00',\n",
+       "                '0 days 01:20:00', '0 days 00:20:00'],\n",
+       "               dtype='timedelta64[ns]', freq=None)"
+      ]
+     },
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1379,7 +1480,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
@@ -1391,7 +1492,7 @@
        "              dtype='datetime64[ns, UTC]', freq=None)"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1412,7 +1513,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
@@ -1427,7 +1528,7 @@
        "              dtype='datetime64[ns, UTC]', freq=None)"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1445,7 +1546,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
@@ -1461,15 +1562,13 @@
        "              dtype='datetime64[ns, UTC]', freq=None)"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "hkg.trading_index(\n",
-    "    start, start, \"30min\", force_close=True, force_break_close=True, intervals=False\n",
-    ")"
+    "hkg.trading_index(start, start, \"30min\", force=True, intervals=False)"
    ]
   },
   {
@@ -1485,6 +1584,487 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### `ignore_breaks`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`ignore_breaks` provides for ignoring any session breaks and instead treating every session as if it were continuous. The following shows how by default `ignore_breaks` is False such that non-trading indices are not introduced within breaks."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>market_open</th>\n",
+       "      <th>break_start</th>\n",
+       "      <th>break_end</th>\n",
+       "      <th>market_close</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2021-12-23 00:00:00+00:00</th>\n",
+       "      <td>2021-12-23 01:30:00</td>\n",
+       "      <td>2021-12-23 04:00:00</td>\n",
+       "      <td>2021-12-23 05:00:00</td>\n",
+       "      <td>2021-12-23 08:00:00</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                  market_open         break_start  \\\n",
+       "2021-12-23 00:00:00+00:00 2021-12-23 01:30:00 2021-12-23 04:00:00   \n",
+       "\n",
+       "                                    break_end        market_close  \n",
+       "2021-12-23 00:00:00+00:00 2021-12-23 05:00:00 2021-12-23 08:00:00  "
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# for reference\n",
+    "schedule.iloc[[0]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>left_side</th>\n",
+       "      <th>right_side</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>IntervalIndex</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>[2021-12-23 01:30:00, 2021-12-23 02:00:00)</th>\n",
+       "      <td>2021-12-23 01:30:00+00:00</td>\n",
+       "      <td>2021-12-23 02:00:00+00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>[2021-12-23 02:00:00, 2021-12-23 02:30:00)</th>\n",
+       "      <td>2021-12-23 02:00:00+00:00</td>\n",
+       "      <td>2021-12-23 02:30:00+00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>[2021-12-23 02:30:00, 2021-12-23 03:00:00)</th>\n",
+       "      <td>2021-12-23 02:30:00+00:00</td>\n",
+       "      <td>2021-12-23 03:00:00+00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>[2021-12-23 03:00:00, 2021-12-23 03:30:00)</th>\n",
+       "      <td>2021-12-23 03:00:00+00:00</td>\n",
+       "      <td>2021-12-23 03:30:00+00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>[2021-12-23 03:30:00, 2021-12-23 04:00:00)</th>\n",
+       "      <td>2021-12-23 03:30:00+00:00</td>\n",
+       "      <td>2021-12-23 04:00:00+00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>[2021-12-23 05:00:00, 2021-12-23 05:30:00)</th>\n",
+       "      <td>2021-12-23 05:00:00+00:00</td>\n",
+       "      <td>2021-12-23 05:30:00+00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>[2021-12-23 05:30:00, 2021-12-23 06:00:00)</th>\n",
+       "      <td>2021-12-23 05:30:00+00:00</td>\n",
+       "      <td>2021-12-23 06:00:00+00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>[2021-12-23 06:00:00, 2021-12-23 06:30:00)</th>\n",
+       "      <td>2021-12-23 06:00:00+00:00</td>\n",
+       "      <td>2021-12-23 06:30:00+00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>[2021-12-23 06:30:00, 2021-12-23 07:00:00)</th>\n",
+       "      <td>2021-12-23 06:30:00+00:00</td>\n",
+       "      <td>2021-12-23 07:00:00+00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>[2021-12-23 07:00:00, 2021-12-23 07:30:00)</th>\n",
+       "      <td>2021-12-23 07:00:00+00:00</td>\n",
+       "      <td>2021-12-23 07:30:00+00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>[2021-12-23 07:30:00, 2021-12-23 08:00:00)</th>\n",
+       "      <td>2021-12-23 07:30:00+00:00</td>\n",
+       "      <td>2021-12-23 08:00:00+00:00</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                           left_side  \\\n",
+       "IntervalIndex                                                          \n",
+       "[2021-12-23 01:30:00, 2021-12-23 02:00:00) 2021-12-23 01:30:00+00:00   \n",
+       "[2021-12-23 02:00:00, 2021-12-23 02:30:00) 2021-12-23 02:00:00+00:00   \n",
+       "[2021-12-23 02:30:00, 2021-12-23 03:00:00) 2021-12-23 02:30:00+00:00   \n",
+       "[2021-12-23 03:00:00, 2021-12-23 03:30:00) 2021-12-23 03:00:00+00:00   \n",
+       "[2021-12-23 03:30:00, 2021-12-23 04:00:00) 2021-12-23 03:30:00+00:00   \n",
+       "[2021-12-23 05:00:00, 2021-12-23 05:30:00) 2021-12-23 05:00:00+00:00   \n",
+       "[2021-12-23 05:30:00, 2021-12-23 06:00:00) 2021-12-23 05:30:00+00:00   \n",
+       "[2021-12-23 06:00:00, 2021-12-23 06:30:00) 2021-12-23 06:00:00+00:00   \n",
+       "[2021-12-23 06:30:00, 2021-12-23 07:00:00) 2021-12-23 06:30:00+00:00   \n",
+       "[2021-12-23 07:00:00, 2021-12-23 07:30:00) 2021-12-23 07:00:00+00:00   \n",
+       "[2021-12-23 07:30:00, 2021-12-23 08:00:00) 2021-12-23 07:30:00+00:00   \n",
+       "\n",
+       "                                                          right_side  \n",
+       "IntervalIndex                                                         \n",
+       "[2021-12-23 01:30:00, 2021-12-23 02:00:00) 2021-12-23 02:00:00+00:00  \n",
+       "[2021-12-23 02:00:00, 2021-12-23 02:30:00) 2021-12-23 02:30:00+00:00  \n",
+       "[2021-12-23 02:30:00, 2021-12-23 03:00:00) 2021-12-23 03:00:00+00:00  \n",
+       "[2021-12-23 03:00:00, 2021-12-23 03:30:00) 2021-12-23 03:30:00+00:00  \n",
+       "[2021-12-23 03:30:00, 2021-12-23 04:00:00) 2021-12-23 04:00:00+00:00  \n",
+       "[2021-12-23 05:00:00, 2021-12-23 05:30:00) 2021-12-23 05:30:00+00:00  \n",
+       "[2021-12-23 05:30:00, 2021-12-23 06:00:00) 2021-12-23 06:00:00+00:00  \n",
+       "[2021-12-23 06:00:00, 2021-12-23 06:30:00) 2021-12-23 06:30:00+00:00  \n",
+       "[2021-12-23 06:30:00, 2021-12-23 07:00:00) 2021-12-23 07:00:00+00:00  \n",
+       "[2021-12-23 07:00:00, 2021-12-23 07:30:00) 2021-12-23 07:30:00+00:00  \n",
+       "[2021-12-23 07:30:00, 2021-12-23 08:00:00) 2021-12-23 08:00:00+00:00  "
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "index = hkg.trading_index(start, start, \"30T\")\n",
+    "show_as_df(index)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Passing `ignore_breaks` as True will include indices through any break."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>left_side</th>\n",
+       "      <th>right_side</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>IntervalIndex</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>[2021-12-23 01:30:00, 2021-12-23 02:00:00)</th>\n",
+       "      <td>2021-12-23 01:30:00+00:00</td>\n",
+       "      <td>2021-12-23 02:00:00+00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>[2021-12-23 02:00:00, 2021-12-23 02:30:00)</th>\n",
+       "      <td>2021-12-23 02:00:00+00:00</td>\n",
+       "      <td>2021-12-23 02:30:00+00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>[2021-12-23 02:30:00, 2021-12-23 03:00:00)</th>\n",
+       "      <td>2021-12-23 02:30:00+00:00</td>\n",
+       "      <td>2021-12-23 03:00:00+00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>[2021-12-23 03:00:00, 2021-12-23 03:30:00)</th>\n",
+       "      <td>2021-12-23 03:00:00+00:00</td>\n",
+       "      <td>2021-12-23 03:30:00+00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>[2021-12-23 03:30:00, 2021-12-23 04:00:00)</th>\n",
+       "      <td>2021-12-23 03:30:00+00:00</td>\n",
+       "      <td>2021-12-23 04:00:00+00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>[2021-12-23 04:00:00, 2021-12-23 04:30:00)</th>\n",
+       "      <td>2021-12-23 04:00:00+00:00</td>\n",
+       "      <td>2021-12-23 04:30:00+00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>[2021-12-23 04:30:00, 2021-12-23 05:00:00)</th>\n",
+       "      <td>2021-12-23 04:30:00+00:00</td>\n",
+       "      <td>2021-12-23 05:00:00+00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>[2021-12-23 05:00:00, 2021-12-23 05:30:00)</th>\n",
+       "      <td>2021-12-23 05:00:00+00:00</td>\n",
+       "      <td>2021-12-23 05:30:00+00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>[2021-12-23 05:30:00, 2021-12-23 06:00:00)</th>\n",
+       "      <td>2021-12-23 05:30:00+00:00</td>\n",
+       "      <td>2021-12-23 06:00:00+00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>[2021-12-23 06:00:00, 2021-12-23 06:30:00)</th>\n",
+       "      <td>2021-12-23 06:00:00+00:00</td>\n",
+       "      <td>2021-12-23 06:30:00+00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>[2021-12-23 06:30:00, 2021-12-23 07:00:00)</th>\n",
+       "      <td>2021-12-23 06:30:00+00:00</td>\n",
+       "      <td>2021-12-23 07:00:00+00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>[2021-12-23 07:00:00, 2021-12-23 07:30:00)</th>\n",
+       "      <td>2021-12-23 07:00:00+00:00</td>\n",
+       "      <td>2021-12-23 07:30:00+00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>[2021-12-23 07:30:00, 2021-12-23 08:00:00)</th>\n",
+       "      <td>2021-12-23 07:30:00+00:00</td>\n",
+       "      <td>2021-12-23 08:00:00+00:00</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                           left_side  \\\n",
+       "IntervalIndex                                                          \n",
+       "[2021-12-23 01:30:00, 2021-12-23 02:00:00) 2021-12-23 01:30:00+00:00   \n",
+       "[2021-12-23 02:00:00, 2021-12-23 02:30:00) 2021-12-23 02:00:00+00:00   \n",
+       "[2021-12-23 02:30:00, 2021-12-23 03:00:00) 2021-12-23 02:30:00+00:00   \n",
+       "[2021-12-23 03:00:00, 2021-12-23 03:30:00) 2021-12-23 03:00:00+00:00   \n",
+       "[2021-12-23 03:30:00, 2021-12-23 04:00:00) 2021-12-23 03:30:00+00:00   \n",
+       "[2021-12-23 04:00:00, 2021-12-23 04:30:00) 2021-12-23 04:00:00+00:00   \n",
+       "[2021-12-23 04:30:00, 2021-12-23 05:00:00) 2021-12-23 04:30:00+00:00   \n",
+       "[2021-12-23 05:00:00, 2021-12-23 05:30:00) 2021-12-23 05:00:00+00:00   \n",
+       "[2021-12-23 05:30:00, 2021-12-23 06:00:00) 2021-12-23 05:30:00+00:00   \n",
+       "[2021-12-23 06:00:00, 2021-12-23 06:30:00) 2021-12-23 06:00:00+00:00   \n",
+       "[2021-12-23 06:30:00, 2021-12-23 07:00:00) 2021-12-23 06:30:00+00:00   \n",
+       "[2021-12-23 07:00:00, 2021-12-23 07:30:00) 2021-12-23 07:00:00+00:00   \n",
+       "[2021-12-23 07:30:00, 2021-12-23 08:00:00) 2021-12-23 07:30:00+00:00   \n",
+       "\n",
+       "                                                          right_side  \n",
+       "IntervalIndex                                                         \n",
+       "[2021-12-23 01:30:00, 2021-12-23 02:00:00) 2021-12-23 02:00:00+00:00  \n",
+       "[2021-12-23 02:00:00, 2021-12-23 02:30:00) 2021-12-23 02:30:00+00:00  \n",
+       "[2021-12-23 02:30:00, 2021-12-23 03:00:00) 2021-12-23 03:00:00+00:00  \n",
+       "[2021-12-23 03:00:00, 2021-12-23 03:30:00) 2021-12-23 03:30:00+00:00  \n",
+       "[2021-12-23 03:30:00, 2021-12-23 04:00:00) 2021-12-23 04:00:00+00:00  \n",
+       "[2021-12-23 04:00:00, 2021-12-23 04:30:00) 2021-12-23 04:30:00+00:00  \n",
+       "[2021-12-23 04:30:00, 2021-12-23 05:00:00) 2021-12-23 05:00:00+00:00  \n",
+       "[2021-12-23 05:00:00, 2021-12-23 05:30:00) 2021-12-23 05:30:00+00:00  \n",
+       "[2021-12-23 05:30:00, 2021-12-23 06:00:00) 2021-12-23 06:00:00+00:00  \n",
+       "[2021-12-23 06:00:00, 2021-12-23 06:30:00) 2021-12-23 06:30:00+00:00  \n",
+       "[2021-12-23 06:30:00, 2021-12-23 07:00:00) 2021-12-23 07:00:00+00:00  \n",
+       "[2021-12-23 07:00:00, 2021-12-23 07:30:00) 2021-12-23 07:30:00+00:00  \n",
+       "[2021-12-23 07:30:00, 2021-12-23 08:00:00) 2021-12-23 08:00:00+00:00  "
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "index = hkg.trading_index(start, start, \"30T\", ignore_breaks=True)\n",
+    "show_as_df(index)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the above example the start of the afternoon session (05.00) is preserved as an indice only because it falls 'on frequency'. This won't be the case for all periods."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>left_side</th>\n",
+       "      <th>right_side</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>IntervalIndex</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>[2021-12-23 01:30:00, 2021-12-23 02:30:00)</th>\n",
+       "      <td>2021-12-23 01:30:00+00:00</td>\n",
+       "      <td>2021-12-23 02:30:00+00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>[2021-12-23 02:30:00, 2021-12-23 03:30:00)</th>\n",
+       "      <td>2021-12-23 02:30:00+00:00</td>\n",
+       "      <td>2021-12-23 03:30:00+00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>[2021-12-23 03:30:00, 2021-12-23 04:30:00)</th>\n",
+       "      <td>2021-12-23 03:30:00+00:00</td>\n",
+       "      <td>2021-12-23 04:30:00+00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>[2021-12-23 04:30:00, 2021-12-23 05:30:00)</th>\n",
+       "      <td>2021-12-23 04:30:00+00:00</td>\n",
+       "      <td>2021-12-23 05:30:00+00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>[2021-12-23 05:30:00, 2021-12-23 06:30:00)</th>\n",
+       "      <td>2021-12-23 05:30:00+00:00</td>\n",
+       "      <td>2021-12-23 06:30:00+00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>[2021-12-23 06:30:00, 2021-12-23 07:30:00)</th>\n",
+       "      <td>2021-12-23 06:30:00+00:00</td>\n",
+       "      <td>2021-12-23 07:30:00+00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>[2021-12-23 07:30:00, 2021-12-23 08:30:00)</th>\n",
+       "      <td>2021-12-23 07:30:00+00:00</td>\n",
+       "      <td>2021-12-23 08:30:00+00:00</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                           left_side  \\\n",
+       "IntervalIndex                                                          \n",
+       "[2021-12-23 01:30:00, 2021-12-23 02:30:00) 2021-12-23 01:30:00+00:00   \n",
+       "[2021-12-23 02:30:00, 2021-12-23 03:30:00) 2021-12-23 02:30:00+00:00   \n",
+       "[2021-12-23 03:30:00, 2021-12-23 04:30:00) 2021-12-23 03:30:00+00:00   \n",
+       "[2021-12-23 04:30:00, 2021-12-23 05:30:00) 2021-12-23 04:30:00+00:00   \n",
+       "[2021-12-23 05:30:00, 2021-12-23 06:30:00) 2021-12-23 05:30:00+00:00   \n",
+       "[2021-12-23 06:30:00, 2021-12-23 07:30:00) 2021-12-23 06:30:00+00:00   \n",
+       "[2021-12-23 07:30:00, 2021-12-23 08:30:00) 2021-12-23 07:30:00+00:00   \n",
+       "\n",
+       "                                                          right_side  \n",
+       "IntervalIndex                                                         \n",
+       "[2021-12-23 01:30:00, 2021-12-23 02:30:00) 2021-12-23 02:30:00+00:00  \n",
+       "[2021-12-23 02:30:00, 2021-12-23 03:30:00) 2021-12-23 03:30:00+00:00  \n",
+       "[2021-12-23 03:30:00, 2021-12-23 04:30:00) 2021-12-23 04:30:00+00:00  \n",
+       "[2021-12-23 04:30:00, 2021-12-23 05:30:00) 2021-12-23 05:30:00+00:00  \n",
+       "[2021-12-23 05:30:00, 2021-12-23 06:30:00) 2021-12-23 06:30:00+00:00  \n",
+       "[2021-12-23 06:30:00, 2021-12-23 07:30:00) 2021-12-23 07:30:00+00:00  \n",
+       "[2021-12-23 07:30:00, 2021-12-23 08:30:00) 2021-12-23 08:30:00+00:00  "
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "index = hkg.trading_index(start, start, \"1H\", ignore_breaks=True)\n",
+    "show_as_df(index)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### `Overlapping indices`"
    ]
   },
@@ -1492,12 +2072,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now, if you've been playing with `trading_index` as you've worked through this tutorial and you've managed to get this far without raising an error, then you haven't been trying hard enough..."
+    "Now, if you've been playing with `trading_index` as you've worked through this tutorial and you've managed to get this far without raising an error, then you just haven't been trying hard enough..."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [
     {
@@ -1508,7 +2088,7 @@
        "              dtype='interval[datetime64[ns, UTC]]')"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1558,7 +2138,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [
     {
@@ -1632,7 +2212,7 @@
        "[2021-12-23 06:45:00, 2021-12-23 08:30:00) 2021-12-23 08:30:00+00:00  "
       ]
      },
-     "execution_count": 33,
+     "execution_count": 38,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1650,7 +2230,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [
     {
@@ -1659,7 +2239,7 @@
        "True"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 39,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1677,7 +2257,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [
     {
@@ -1686,7 +2266,7 @@
        "False"
       ]
      },
-     "execution_count": 35,
+     "execution_count": 40,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1704,7 +2284,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [
     {
@@ -1778,7 +2358,7 @@
        "[2021-12-23 06:46:00, 2021-12-23 08:32:00) 2021-12-23 08:32:00+00:00  "
       ]
      },
-     "execution_count": 36,
+     "execution_count": 41,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1796,7 +2376,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [
     {
@@ -1870,7 +2450,7 @@
        "[2021-12-23 06:51:00, 2021-12-23 08:42:00) 2021-12-23 08:42:00+00:00  "
       ]
      },
-     "execution_count": 37,
+     "execution_count": 42,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1889,7 +2469,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [
     {
@@ -1900,7 +2480,7 @@
        "               dtype='timedelta64[ns]', freq=None)"
       ]
      },
-     "execution_count": 38,
+     "execution_count": 43,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1920,7 +2500,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [
     {
@@ -1987,7 +2567,7 @@
        "[2021-12-23 07:30:00, 2021-12-23 10:00:00) 2021-12-23 10:00:00+00:00  "
       ]
      },
-     "execution_count": 39,
+     "execution_count": 44,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2007,7 +2587,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [
     {
@@ -2075,7 +2655,7 @@
        "2021-12-03 00:00:00+00:00 2021-12-03 23:00:00  "
       ]
      },
-     "execution_count": 40,
+     "execution_count": 45,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2097,7 +2677,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 46,
    "metadata": {},
    "outputs": [
     {
@@ -2206,7 +2786,7 @@
        "[2021-12-03 15:00:00, 2021-12-03 23:00:00) 2021-12-03 23:00:00+00:00  "
       ]
      },
-     "execution_count": 41,
+     "execution_count": 46,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2248,7 +2828,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 48,
    "metadata": {},
    "outputs": [
     {
@@ -2374,7 +2954,7 @@
        "[618 rows x 2 columns]"
       ]
      },
-     "execution_count": 43,
+     "execution_count": 48,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2424,7 +3004,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 50,
    "metadata": {},
    "outputs": [
     {
@@ -2435,7 +3015,7 @@
        "              dtype='datetime64[ns, UTC]', freq=None)"
       ]
      },
-     "execution_count": 45,
+     "execution_count": 50,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/exchange_calendars/calendar_helpers.py
+++ b/exchange_calendars/calendar_helpers.py
@@ -385,9 +385,10 @@ class _TradingIndex:
         force_close: bool,
         force_break_close: bool,
         curtail_overlaps: bool,
+        ignore_breaks: bool,
     ):
         self.closed = closed
-        self.force_break_close = force_break_close
+        self.force_break_close = False if ignore_breaks else force_break_close
         self.force_close = force_close
         self.curtail_overlaps = curtail_overlaps
 
@@ -401,11 +402,15 @@ class _TradingIndex:
 
         self.opens = calendar.opens_nanos[slce]
         self.closes = calendar.closes_nanos[slce]
-        self.break_starts = calendar.break_starts_nanos[slce]
-        self.break_ends = calendar.break_ends_nanos[slce]
 
-        self.mask = self.break_starts != pd.NaT.value  # break mask
-        self.has_break = self.mask.any()
+        if ignore_breaks:
+            self.has_break = False
+        else:
+            self.break_starts = calendar.break_starts_nanos[slce]
+            self.break_ends = calendar.break_ends_nanos[slce]
+
+            self.mask = self.break_starts != pd.NaT.value  # break mask
+            self.has_break = self.mask.any()
 
         self.defaults = {
             "closed": self.closed,

--- a/exchange_calendars/exchange_calendar.py
+++ b/exchange_calendars/exchange_calendar.py
@@ -2191,7 +2191,9 @@ class ExchangeCalendar(ABC):
         closed: str = "left",  # when move to min 3.8 Literal["left", "right", "both", "neither"]
         force_close: bool = False,
         force_break_close: bool = False,
+        force: bool | None = None,
         curtail_overlaps: bool = False,
+        ignore_breaks: bool = False,
         parse: bool = True,
     ) -> pd.DatetimeIndex | pd.IntervalIndex:
         """Create a trading index.
@@ -2266,6 +2268,7 @@ class ExchangeCalendar(ABC):
             `force_break_close`.
 
         force_close : default: False
+            (ignored if `force` is passed.)
             (ignored if `period` is '1d')
             (irrelevant if `intervals` is False and `closed` is "left" or
             "neither")
@@ -2280,6 +2283,7 @@ class ExchangeCalendar(ABC):
             non-trading period.
 
         force_break_close : default: False
+            (ignored if `force` is passed.)
             (ignored if `period` is '1d'.)
             (irrelevant if `intervals` is False and `closed` is "left" or
             "neither.)
@@ -2292,6 +2296,15 @@ class ExchangeCalendar(ABC):
             If False, defines right side of this period after the break
             start. In this case the represented period will include a
             non-trading period.
+
+        force : optional
+            (ignored if `period` is '1d'.)
+            (irrelevant if `intervals` is False and `closed` is "left" or
+            "neither.)
+
+            Convenience option to set both `force_close` and
+            `force_break_close`. If passed then values passsed to
+            `force_close` and `force_break_close` will be ignored.
 
         curtail_overlaps : default: False
             (ignored if `period` is '1d')
@@ -2309,6 +2322,18 @@ class ExchangeCalendar(ABC):
                 all periods.)
 
                 If False, will raise IntervalsOverlapError.
+
+        ignore_breaks : default: False
+            (ignored if `period` is '1d'.)
+            (irrelevant if no session has a break)
+
+            Defines whether trading index should respect session breaks.
+
+            If False, treat sessions with breaks as comprising independent
+            morning and afternoon subsessions.
+
+            If True, treat all sessions as continuous, ignoring any
+            breaks.
 
         parse : default: True
             Determines if `start` and `end` values are parsed. If these
@@ -2373,6 +2398,9 @@ class ExchangeCalendar(ABC):
                 f"If `intervals` is True then `closed` cannot be '{closed}'."
             )
 
+        if force is not None:
+            force_close = force_break_close = force
+
         # method exposes public methods of _TradingIndex.
         _trading_index = _TradingIndex(
             self,
@@ -2383,6 +2411,7 @@ class ExchangeCalendar(ABC):
             force_close,
             force_break_close,
             curtail_overlaps,
+            ignore_breaks,
         )
 
         if not intervals:

--- a/tests/test_exchange_calendar.py
+++ b/tests/test_exchange_calendar.py
@@ -3675,7 +3675,7 @@ class ExchangeCalendarTestBase:
 
         Assumes default value (False) for each of `force_close`,
         `force_break_close` and `curtail_overlaps`. See test class
-        `test_exchange_calendars.TestTradingIndex` for more comprehensive
+        `test_calendar_helpers.TestTradingIndex` for more comprehensive
         fuzz testing of select calendars (and parsing testing).
         """
         cal, ans = calendars["left"], answers["left"]


### PR DESCRIPTION
Adds functionality to `ExchangeCalendar.trading_index`:
 - adds `force` convenience option to force both close and break close.
 - adds `ignore_breaks` option to treat sessions with breaks as if continuous.
- adds tests.
- updates tutorial.

Also updates expected release date of 4.0 to April (I'm hopeful this won't slip any further!)