### PR TITLE
Add doc + types and moves 'special offsets' implementation to XKRX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,6 @@ etc/solar-ecliptic-longitude/*
 
 # Vscode
 .vscode
+
+# not intended for inclusion to public project
+/_local

--- a/exchange_calendars/exchange_calendar.py
+++ b/exchange_calendars/exchange_calendar.py
@@ -561,40 +561,95 @@ class ExchangeCalendar(ABC):
 
     @property
     def adhoc_holidays(self) -> list[pd.Timestamp]:
-        """Non-regular holidays.
+        """List of non-regular holidays.
 
         Returns
         -------
         list[pd.Timestamp]
-            List of tz-naive timestamps representing non-regular closes.
+            List of tz-naive timestamps representing non-regular holidays.
         """
         return []
 
     @property
-    def special_opens(self) -> list[tuple[pd.Timestamp, HolidayCalendar]]:
-        """Non-regular open times and corresponding HolidayCalendars."""
-        return []
+    def special_opens(self) -> list[tuple[datetime.time, HolidayCalendar]]:
+        """Regular non-standard open times.
 
-    @property
-    def special_opens_adhoc(self) -> list[tuple[datetime.time, pd.DatetimeIndex]]:
-        """Adhoc non-regular open times and corresponding sessions.
+        Example of what would be defined as a special open:
+            "EVERY YEAR on national lie-in day the exchange opens
+            at 13:00 rather than the standard 09:00".
 
-        Defines non-regular opens that cannot be otherwise codified within
-        within `special_opens`.
+        Returns
+        -------
+        list[tuple[datetime.time, HolidayCalendar]]:
+            list of tuples each describing a regular non-standard open
+            time:
+                [0] datetime.time: regular non-standard open time.
+                [1] HolidayCalendar: holiday calendar describing occurence.
         """
         return []
 
     @property
-    def special_closes(self) -> list[tuple[pd.Timestamp, HolidayCalendar]]:
-        """Non-regular close times and corresponding HolidayCalendars."""
+    def special_opens_adhoc(
+        self,
+    ) -> list[tuple[datetime.time, pd.Timestamp | list[pd.Timestamp]]]:
+        """Adhoc non-standard open times.
+
+        Defines non-standard open times that cannot be otherwise codified
+        within within `special_opens`.
+
+        Example of an event to define as an adhoc special open:
+            "On 2022-02-14 due to a typhoon the exchange opened at 13:00,
+            rather than the standard 09:00".
+
+        Returns
+        -------
+        list[tuple[datetime.time, pd.Timestamp | list[pd.Timestamp]]]:
+            List of tuples each describing an adhoc non-standard open time:
+                [0] datetime.time: non-standard open time.
+                [1] pd.Timestamp | list[pd.Timestamp]: date or dates
+                    corresponding with the non-standard open time.
+        """
         return []
 
     @property
-    def special_closes_adhoc(self) -> list[tuple[datetime.time, pd.DatetimeIndex]]:
-        """Adhoc non-regular close times and corresponding sessions.
+    def special_closes(self) -> list[tuple[datetime.time, HolidayCalendar]]:
+        """Regular non-standard close times.
 
-        Defines non-regular closes that cannot be otherwise codified within
-        `special_closes`.
+        Example of what would be defined as a special close:
+            "On christmas eve the exchange closes at 14:00 rather than
+            the standard 17:00".
+
+        Returns
+        -------
+        list[tuple[datetime.time, HolidayCalendar]]:
+            list of tuples each describing a regular non-standard close
+            time:
+                [0] datetime.time: regular non-standard close time.
+                [1] HolidayCalendar: holiday calendar describing occurence.
+        """
+        return []
+
+    @property
+    def special_closes_adhoc(
+        self,
+    ) -> list[tuple[datetime.time, pd.Timestamp | list[pd.Timestamp]]]:
+        """Adhoc non-standard close times.
+
+        Defines non-standard close times that cannot be otherwise codified
+        within within `special_closes`.
+
+        Example of an event to define as an adhoc special close:
+            "On 2022-02-19 due to a typhoon the exchange closed at 12:00,
+            rather than the standard 16:00".
+
+        Returns
+        -------
+        list[tuple[datetime.time, pd.Timestamp | list[pd.Timestamp]]]:
+            List of tuples each describing an adhoc non-standard close
+            time:
+                [0] datetime.time: non-standard close time.
+                [1] pd.Timestamp | list[pd.Timestamp]: date or dates
+                    corresponding with the non-standard close time.
         """
         return []
 

--- a/exchange_calendars/exchange_calendar_xkrx.py
+++ b/exchange_calendars/exchange_calendar_xkrx.py
@@ -16,8 +16,9 @@
 from datetime import time
 
 import pandas as pd
-from pytz import timezone
+from pytz import timezone, UTC
 from pandas.tseries.holiday import Holiday
+from pandas.tseries.offsets import CustomBusinessDay
 
 from .exchange_calendar import HolidayCalendar
 from .precomputed_exchange_calendar import PrecomputedExchangeCalendar
@@ -26,7 +27,9 @@ from .xkrx_holidays import (
     precomputed_krx_holidays,
     precomputed_csat_days,
 )
+from .pandas_extensions.offsets import MultipleWeekmaskCustomBusinessDay
 from .pandas_extensions.korean_holiday import next_business_day
+from .utils.memoize import lazyval
 
 
 class XKRXExchangeCalendar(PrecomputedExchangeCalendar):
@@ -116,6 +119,12 @@ class XKRXExchangeCalendar(PrecomputedExchangeCalendar):
 
     @property
     def special_weekmasks(self):
+        """
+        Returns
+        -------
+        list: List of (date, date, str) tuples that represent special
+         weekmasks that applies between dates.
+        """
         return [
             (None, pd.Timestamp("1998-12-06"), "1111110"),
         ]
@@ -143,6 +152,13 @@ class XKRXExchangeCalendar(PrecomputedExchangeCalendar):
 
     @property
     def special_offsets(self):
+        """
+        Returns
+        -------
+        list: List of (timedelta, timedelta, timedelta, timedelta, AbstractHolidayCalendar) tuples
+         that represent special open, break_start, break_end, close offsets
+         and corresponding HolidayCalendars.
+        """
         return [
             (
                 pd.Timedelta(1, unit="h"),
@@ -168,6 +184,13 @@ class XKRXExchangeCalendar(PrecomputedExchangeCalendar):
 
     @property
     def special_offsets_adhoc(self):
+        """
+        Returns
+        -------
+        list: List of (timedelta, timedelta, timedelta, timedelta, DatetimeIndex) tuples
+         that represent special open, break_start, break_end, close offsets
+         and corresponding DatetimeIndexes.
+        """
         return [
             (
                 pd.Timedelta(30, unit="m"),
@@ -188,6 +211,154 @@ class XKRXExchangeCalendar(PrecomputedExchangeCalendar):
                 ],
             ),
         ]
+
+    def _overwrite_special_offsets(
+        self,
+        session_labels,
+        opens_or_closes,
+        calendars,
+        ad_hoc_dates,
+        start_date,
+        end_date,
+        strict=False,
+    ):
+        # Short circuit when nothing to apply.
+        if opens_or_closes is None or not len(opens_or_closes):
+            return
+
+        len_m, len_oc = len(session_labels), len(opens_or_closes)
+        if len_m != len_oc:
+            raise ValueError(
+                "Found misaligned dates while building calendar.\n"
+                "Expected session_labels to be the same length as "
+                "open_or_closes but,\n"
+                "len(session_labels)=%d, len(open_or_closes)=%d" % (len_m, len_oc)
+            )
+
+        regular = []
+        for offset, calendar in calendars:
+            days = calendar.holidays(start_date, end_date)
+            series = pd.Series(
+                index=pd.DatetimeIndex(days, tz=UTC),
+                data=offset,
+            )
+            regular.append(series)
+
+        ad_hoc = []
+        for offset, datetimes in ad_hoc_dates:
+            series = pd.Series(
+                index=pd.to_datetime(datetimes, utc=True),
+                data=offset,
+            )
+            ad_hoc.append(series)
+
+        merged = regular + ad_hoc
+        if not merged:
+            return pd.Series([], dtype="timedelta64[ns]")
+
+        result = pd.concat(merged).sort_index()
+        offsets = result.loc[(result.index >= start_date) & (result.index <= end_date)]
+
+        # Find the array indices corresponding to each special date.
+        indexer = session_labels.get_indexer(offsets.index)
+
+        # -1 indicates that no corresponding entry was found.  If any -1s are
+        # present, then we have special dates that doesn't correspond to any
+        # trading day.
+        if -1 in indexer and strict:
+            bad_dates = list(offsets.index[indexer == -1])
+            raise ValueError("Special dates %s are not trading days." % bad_dates)
+
+        special_opens_or_closes = opens_or_closes[indexer] + offsets
+
+        # Short circuit when nothing to apply.
+        if not len(special_opens_or_closes):
+            return
+
+        # NOTE: This is a slightly dirty hack.  We're in-place overwriting the
+        # internal data of an Index, which is conceptually immutable.  Since we're
+        # maintaining sorting, this should be ok, but this is a good place to
+        # sanity check if things start going haywire with calendar computations.
+        opens_or_closes.values[indexer] = special_opens_or_closes.values
+
+    def apply_special_offsets(self, session_labels, start, end):
+        """Evaluate and overwrite special offsets."""
+        _special_offsets = self.special_offsets
+        _special_offsets_adhoc = self.special_offsets_adhoc
+
+        _special_open_offsets = [
+            (t[0], t[-1]) for t in _special_offsets if t[0] is not None
+        ]
+        _special_open_offsets_adhoc = [
+            (t[0], t[-1]) for t in _special_offsets_adhoc if t[0] is not None
+        ]
+        _special_break_start_offsets = [
+            (t[1], t[-1]) for t in _special_offsets if t[1] is not None
+        ]
+        _special_break_start_offsets_adhoc = [
+            (t[1], t[-1]) for t in _special_offsets_adhoc if t[1] is not None
+        ]
+        _special_break_end_offsets = [
+            (t[2], t[-1]) for t in _special_offsets if t[2] is not None
+        ]
+        _special_break_end_offsets_adhoc = [
+            (t[2], t[-1]) for t in _special_offsets_adhoc if t[2] is not None
+        ]
+        _special_close_offsets = [
+            (t[3], t[-1]) for t in _special_offsets if t[3] is not None
+        ]
+        _special_close_offsets_adhoc = [
+            (t[3], t[-1]) for t in _special_offsets_adhoc if t[3] is not None
+        ]
+
+        self._overwrite_special_offsets(
+            session_labels,
+            self._opens,
+            _special_open_offsets,
+            _special_open_offsets_adhoc,
+            start,
+            end,
+        )
+        self._overwrite_special_offsets(
+            session_labels,
+            self._break_starts,
+            _special_break_start_offsets,
+            _special_break_start_offsets_adhoc,
+            start,
+            end,
+        )
+        self._overwrite_special_offsets(
+            session_labels,
+            self._break_ends,
+            _special_break_end_offsets,
+            _special_break_end_offsets_adhoc,
+            start,
+            end,
+        )
+        self._overwrite_special_offsets(
+            session_labels,
+            self._closes,
+            _special_close_offsets,
+            _special_close_offsets_adhoc,
+            start,
+            end,
+        )
+
+    @lazyval
+    def day(self):
+        if self.special_weekmasks:
+            return MultipleWeekmaskCustomBusinessDay(
+                holidays=self.adhoc_holidays,
+                calendar=self.regular_holidays,
+                weekmask=self.weekmask,
+                weekmasks=self.special_weekmasks,
+            )
+        else:
+            return CustomBusinessDay(
+                holidays=self.adhoc_holidays,
+                calendar=self.regular_holidays,
+                weekmask=self.weekmask,
+            )
 
 
 class PrecomputedXKRXExchangeCalendar(PrecomputedExchangeCalendar):

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ if __name__ == "__main__":
         install_requires=reqs,
         extras_require={
             "dev": [
+                "black",
                 "flake8",
                 "pytest",
                 "pytest-benchmark",

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,6 @@ if __name__ == "__main__":
         install_requires=reqs,
         extras_require={
             "dev": [
-                "black",
                 "flake8",
                 "pytest",
                 "pytest-benchmark",

--- a/tests/test_exchange_calendar.py
+++ b/tests/test_exchange_calendar.py
@@ -2072,9 +2072,7 @@ class ExchangeCalendarTestBase:
             "special_opens_adhoc",
             "special_closes",
             "special_closes_adhoc",
-            "special_weekmasks",
-            "special_offsets",
-            "special_offsets_adhoc",
+            "apply_special_offsets",
         ]
 
     @pytest.fixture(scope="class")
@@ -2208,7 +2206,12 @@ class ExchangeCalendarTestBase:
         for name in non_valid_overrides:
             on_cls, on_base = getattr(cls, name), getattr(ExchangeCalendar, name)
             # covers properties, instance methods and class mathods...
-            assert on_cls == on_base or on_cls.__qualname__ == on_base.__qualname__
+            try:
+                assert on_cls == on_base or on_cls.__qualname__ == on_base.__qualname__
+            except AttributeError:
+                if not (cls.name == "XKRX" and name == "day"):
+                    # allow exchange_calendar_xkrx to overwrite 'day'.
+                    raise
 
     def test_calculated_against_csv(self, default_calendar_with_answers):
         calendar, ans = default_calendar_with_answers


### PR DESCRIPTION
Extends documentation and adds type annotations to `ExchangeCalendar` "calendar-definition" properties.

Moves 'special offsets' implementation from `ExchangeCalendar` to `XKRXExchangeCalendar` (leaving a `apply_special_offsets` hook into the `ExchangeCalendar` constructor). The implementation added a fair bit of bulk to `ExchangeCalendar` although is used only by `XKRXExchangeCalendar`. Given that no other calendar uses it, and that it's anticipated `XKRXExchangeCalendar` will move to hardcoded dates anyway (#128), this PR explicitly makes the implementation specific to `XKRXExchangeCalendar`.

Also
- a little general linting.
- tried to add 'black' to dev environment, reverted due to pip conflicts.