### PR TITLE
Change sessions to tz-naive, times to UTC

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - master
+      - v4
   pull_request:
     branches:
       - master
+      - v4
 
 jobs:
   build-and-test:

--- a/exchange_calendars/calendar_helpers.py
+++ b/exchange_calendars/calendar_helpers.py
@@ -141,8 +141,8 @@ def parse_timestamp(
     raise_oob : default: True
         True to raise MinuteOutOfBounds if `timestamp` is earlier than the
         first trading minute or later than the last trading minute of
-        `calendar`. Pass as False if `timestamp` represents a Minute (as
-        opposed to a Date). If True then `calendar` must be passed.
+        `calendar`. Pass as False if `timestamp` represents a Date (as
+        opposed to a Minute). If True then `calendar` must be passed.
 
     side : optional, {None, 'left', 'right', 'both', 'neither'}
         The side that determines which minutes at a session's bounds are
@@ -280,7 +280,7 @@ def parse_date(
     Returns
      -------
      pd.Timestamp
-         pd.Timestamp (UTC with time component of 00:00).
+         pd.Timestamp (timezone naive with time component of 00:00).
 
      Raises
      ------
@@ -288,8 +288,7 @@ def parse_date(
 
      ValueError
          If `date` time component is not 00:00.
-
-         If `date` is timezone aware and timezone is not UTC.
+         If `date` is timezone aware.
 
     exchange_calendars.errors.DateOutOfBounds
         If `raise_oob` True and `date` parses to a valid timestamp although
@@ -301,10 +300,10 @@ def parse_date(
     # if it falls within the minute that follows midnight.
     ts = parse_timestamp(date, param_name, raise_oob=False, side="left", utc=False)
 
-    if not (ts.tz is None or ts.tz.zone == "UTC"):
+    if ts.tz is not None:
         raise ValueError(
             f"Parameter `{param_name}` received with timezone defined as '{ts.tz.zone}'"
-            f" although a Date must be timezone naive or have timezone as 'UTC'."
+            f" although a Date must be timezone naive."
         )
 
     if not ts == ts.normalize():
@@ -312,9 +311,6 @@ def parse_date(
             f"Parameter `{param_name}` parsed as '{ts}' although a Date must have"
             f" a time component of 00:00."
         )
-
-    if ts.tz is None:
-        ts = ts.tz_localize("UTC")
 
     if raise_oob:
         if calendar is None:
@@ -346,8 +342,8 @@ def parse_session(
     Returns
     -------
     pd.Timestamp
-        pd.Timestamp (UTC with time component of 00:00) that represents a
-        real session of `calendar`.
+        pd.Timestamp (timezone naive and with time component of 00:00) that
+        represents a real session of `calendar`.
 
     Raises
     ------

--- a/exchange_calendars/errors.py
+++ b/exchange_calendars/errors.py
@@ -224,7 +224,7 @@ class NotTradingMinuteError(ValueError):
                 " is earlier than the first trading minute of calendar"
                 f" '{self.calendar.name}' ('{self.calendar.first_session}')."
             )
-        elif self.minute > self.calendar.last_session:
+        elif self.minute > self.calendar.last_minute:
             msg += (
                 " is later than the last trading minute of calendar"
                 f" '{self.calendar.name}' ('{self.calendar.last_session}')."

--- a/exchange_calendars/exchange_calendar_aixk.py
+++ b/exchange_calendars/exchange_calendar_aixk.py
@@ -8,7 +8,7 @@ from pandas.tseries.holiday import (
     nearest_workday,
     next_workday,
 )
-from pytz import timezone
+import pytz
 
 from .common_holidays import new_years_day, eid_al_adha_first_day
 from .exchange_calendar import (
@@ -148,7 +148,7 @@ class AIXKExchangeCalendar(ExchangeCalendar):
 
     name = "AIXK"
 
-    tz = timezone("Asia/Almaty")
+    tz = pytz.timezone("Asia/Almaty")
 
     open_times = ((None, time(11)),)
 
@@ -156,7 +156,7 @@ class AIXKExchangeCalendar(ExchangeCalendar):
 
     @property
     def bound_start(self) -> pd.Timestamp:
-        return pd.Timestamp("2017-01-01", tz="UTC")
+        return pd.Timestamp("2017-01-01")
 
     def _bound_start_error_msg(self, start: pd.Timestamp) -> str:
         msg = super()._bound_start_error_msg(start)

--- a/exchange_calendars/exchange_calendar_xdub.py
+++ b/exchange_calendars/exchange_calendar_xdub.py
@@ -15,7 +15,7 @@
 
 from datetime import time
 
-from pandas import Timestamp
+import pandas as pd
 from pandas.tseries.holiday import (
     MO,
     DateOffset,
@@ -25,7 +25,7 @@ from pandas.tseries.holiday import (
     previous_friday,
     weekend_to_monday,
 )
-from pytz import UTC, timezone
+import pytz
 
 from .common_holidays import (
     boxing_day,
@@ -97,9 +97,9 @@ LastTradingDayOfCalendarYear = Holiday(
 )
 
 # Ad hoc closes.
-March1BadWeather = Timestamp("2018-03-01", tz=UTC)
+March1BadWeather = pd.Timestamp("2018-03-01")
 # Ad hoc holidays.
-March2BadWeather = Timestamp("2018-03-02")
+March2BadWeather = pd.Timestamp("2018-03-02")
 
 
 class XDUBExchangeCalendar(ExchangeCalendar):
@@ -128,7 +128,7 @@ class XDUBExchangeCalendar(ExchangeCalendar):
     """
 
     name = "XDUB"
-    tz = timezone("Europe/Dublin")
+    tz = pytz.timezone("Europe/Dublin")
     open_times = ((None, time(8)),)
     close_times = ((None, time(16, 28)),)
     regular_early_close = time(12, 28)
@@ -173,4 +173,4 @@ class XDUBExchangeCalendar(ExchangeCalendar):
 
     @property
     def special_closes_adhoc(self):
-        return [(self.regular_early_close, [March1BadWeather])]
+        return [(self.regular_early_close, pd.DatetimeIndex([March1BadWeather]))]

--- a/exchange_calendars/exchange_calendar_xhkg.py
+++ b/exchange_calendars/exchange_calendar_xhkg.py
@@ -22,7 +22,7 @@ import pandas as pd
 import toolz
 from pandas.tseries.holiday import EasterMonday, GoodFriday, Holiday, sunday_to_monday
 from pandas.tseries.offsets import LastWeekOfMonth, WeekOfMonth
-from pytz import timezone
+import pytz
 
 from .common_holidays import (
     boxing_day,
@@ -224,7 +224,9 @@ HKAdhocClosures = [
     # pd.Timestamp(2017-06-12'),  # 台风苗柏1702,期货夜盘17:35休市
     pd.Timestamp("2017-08-23"),  # 台风天鸽1713
     pd.Timestamp("2020-10-13"),  # 台风浪卡2016
-    pd.Timestamp("2021-10-13"),  # https://www.hkex.com.hk/News/Market-Communications/2021/2110132news?sc_lang=en
+    pd.Timestamp(
+        "2021-10-13"
+    ),  # https://www.hkex.com.hk/News/Market-Communications/2021/2110132news?sc_lang=en
 ]
 
 
@@ -270,7 +272,7 @@ class XHKGExchangeCalendar(PrecomputedExchangeCalendar):
     """
 
     name = "XHKG"
-    tz = timezone("Asia/Hong_Kong")
+    tz = pytz.timezone("Asia/Hong_Kong")
 
     open_times = (
         (None, time(10)),
@@ -447,7 +449,7 @@ class XHKGExchangeCalendar(PrecomputedExchangeCalendar):
             return arr[np.all(predicates, axis=0)]
 
         return [
-            (time, selection(lunar_new_years_eve, start, end))
+            (time, pd.DatetimeIndex(selection(lunar_new_years_eve, start, end)))
             for (start, time), (end, _) in toolz.sliding_window(
                 2,
                 toolz.concatv(self.regular_early_close_times, [(None, None)]),

--- a/exchange_calendars/exchange_calendar_xist.py
+++ b/exchange_calendars/exchange_calendar_xist.py
@@ -18,7 +18,7 @@ from itertools import chain
 
 import pandas as pd
 from pandas.tseries.holiday import Holiday
-from pytz import timezone
+import pytz
 
 from .common_holidays import (
     eid_al_adha_first_day,
@@ -117,7 +117,7 @@ class XISTExchangeCalendar(ExchangeCalendar):
 
     name = "XIST"
 
-    tz = timezone("Europe/Istanbul")
+    tz = pytz.timezone("Europe/Istanbul")
 
     open_times = ((None, time(10)),)
 
@@ -177,5 +177,5 @@ class XISTExchangeCalendar(ExchangeCalendar):
 
     @property
     def special_closes_adhoc(self):
-        early_close_days = EidAlFitrHalfDay + EidAlAdhaHalfDay
+        early_close_days = pd.DatetimeIndex(EidAlFitrHalfDay + EidAlAdhaHalfDay)
         return [(self.regular_early_close, early_close_days)]

--- a/exchange_calendars/exchange_calendar_xkls.py
+++ b/exchange_calendars/exchange_calendar_xkls.py
@@ -16,7 +16,8 @@
 from datetime import time
 from itertools import chain
 
-from pytz import timezone
+import pandas as pd
+import pytz
 
 from .exchange_calendar import HolidayCalendar, ExchangeCalendar
 from .xkls_holidays import (
@@ -77,7 +78,7 @@ class XKLSExchangeCalendar(ExchangeCalendar):
 
     name = "XKLS"
 
-    tz = timezone("Asia/Kuala_Lumpur")
+    tz = pytz.timezone("Asia/Kuala_Lumpur")
 
     open_times = ((None, time(9)),)
 
@@ -121,5 +122,7 @@ class XKLSExchangeCalendar(ExchangeCalendar):
     @property
     def special_closes_adhoc(self):
         # Regular early closes on Chinese New Years Eve, Eid al-Fitr Eve
-        early_close_days = list(set(ChineseNewYearsHalfDay + EidAlFitrHalfDay))
+        early_close_days = pd.DatetimeIndex(
+            set(ChineseNewYearsHalfDay + EidAlFitrHalfDay)
+        )
         return [(self.regular_early_close, early_close_days)]

--- a/exchange_calendars/exchange_calendar_xnys.py
+++ b/exchange_calendars/exchange_calendar_xnys.py
@@ -18,7 +18,7 @@ from itertools import chain
 
 from pandas import DatetimeIndex
 from pandas.tseries.holiday import GoodFriday, USLaborDay
-from pytz import UTC, timezone
+import pytz
 
 from .exchange_calendar import HolidayCalendar, ExchangeCalendar
 from .us_holidays import (
@@ -157,7 +157,7 @@ class XNYSExchangeCalendar(ExchangeCalendar):
 
     name = "XNYS"
 
-    tz = timezone("America/New_York")
+    tz = pytz.timezone("America/New_York")
 
     open_times = ((None, time(9, 30)),)
 
@@ -252,8 +252,7 @@ class XNYSExchangeCalendar(ExchangeCalendar):
                         "1997-12-26",
                         "1999-12-31",
                         "2003-12-26",
-                    ],
-                    tz=UTC,
+                    ]
                 ),
             )
         ]

--- a/exchange_calendars/exchange_calendar_xshg.py
+++ b/exchange_calendars/exchange_calendar_xshg.py
@@ -1,7 +1,7 @@
 from datetime import time
 
 import pandas as pd
-from pytz import timezone
+import pytz
 
 from .precomputed_exchange_calendar import PrecomputedExchangeCalendar
 
@@ -590,7 +590,7 @@ class XSHGExchangeCalendar(PrecomputedExchangeCalendar):
     """
 
     name = "XSHG"
-    tz = timezone("Asia/Shanghai")
+    tz = pytz.timezone("Asia/Shanghai")
     open_times = ((None, time(9, 30)),)
     break_start_times = ((None, time(11, 30)),)
     break_end_times = ((None, time(13, 0)),)
@@ -602,4 +602,4 @@ class XSHGExchangeCalendar(PrecomputedExchangeCalendar):
 
     @property
     def bound_start(self) -> pd.Timestamp:
-        return pd.Timestamp("1990-12-03", tz="Asia/Shanghai")
+        return pd.Timestamp("1990-12-03")

--- a/exchange_calendars/exchange_calendar_xtks.py
+++ b/exchange_calendars/exchange_calendar_xtks.py
@@ -2,7 +2,7 @@ from datetime import time
 from itertools import chain
 
 import pandas as pd
-from pytz import UTC, timezone
+import pytz
 
 from .exchange_calendar import HolidayCalendar, ExchangeCalendar
 from .xtks_holidays import (
@@ -80,7 +80,7 @@ class XTKSExchangeCalendar(ExchangeCalendar):
 
     name = "XTKS"
 
-    tz = timezone("Asia/Tokyo")
+    tz = pytz.timezone("Asia/Tokyo")
 
     open_times = ((None, time(9)),)
     break_start_times = ((None, time(11, 30)),)
@@ -90,7 +90,7 @@ class XTKSExchangeCalendar(ExchangeCalendar):
     @property
     def bound_start(self) -> pd.Timestamp:
         # not tracking holiday info farther back than 1997
-        return pd.Timestamp("1997-01-01", tz=UTC)
+        return pd.Timestamp("1997-01-01")
 
     @property
     def regular_holidays(self):

--- a/exchange_calendars/lunisolar_holidays.py
+++ b/exchange_calendars/lunisolar_holidays.py
@@ -11,7 +11,7 @@ import pandas as pd
 # See Also
 # --------
 # exchange_calendars/etc/lunisolar chinese-new-year
-chinese_lunar_new_year_dates = pd.to_datetime(
+chinese_lunar_new_year_dates = pd.DatetimeIndex(
     [
         "1960-01-28",
         "1961-02-15",
@@ -112,7 +112,7 @@ chinese_lunar_new_year_dates = pd.to_datetime(
 # See Also
 # --------
 # exchange_calendars/etc/lunisolar qingming-festival
-qingming_festival_dates = pd.to_datetime(
+qingming_festival_dates = pd.DatetimeIndex(
     [
         "1960-04-05",
         "1961-04-05",
@@ -219,7 +219,7 @@ qingming_festival_dates = pd.to_datetime(
 # The holiday "Buddha's Birthday" is celebrated in many countries, though
 # different calendars are used. This function is for Buddha's Birthday on
 # the Chinese Lunisolar Calendar, where it is the 8th day of the 4th month.
-chinese_buddhas_birthday_dates = pd.to_datetime(
+chinese_buddhas_birthday_dates = pd.DatetimeIndex(
     [
         "1959-05-15",
         "1960-05-03",
@@ -321,7 +321,7 @@ chinese_buddhas_birthday_dates = pd.to_datetime(
 # See Also
 # --------
 # exchange_calendars/etc/lunisolar dragon-boat-festival
-dragon_boat_festival_dates = pd.to_datetime(
+dragon_boat_festival_dates = pd.DatetimeIndex(
     [
         "1960-05-29",
         "1961-06-17",
@@ -423,7 +423,7 @@ dragon_boat_festival_dates = pd.to_datetime(
 # See Also
 # --------
 # exchange_calendars/etc/lunisolar mid-autumn-festival
-mid_autumn_festival_dates = pd.to_datetime(
+mid_autumn_festival_dates = pd.DatetimeIndex(
     [
         "1960-10-05",
         "1961-09-24",
@@ -523,7 +523,7 @@ mid_autumn_festival_dates = pd.to_datetime(
 # See Also
 # --------
 # exchange_calendars/etc/lunisolar double-ninth-festival
-double_ninth_festival_dates = pd.to_datetime(
+double_ninth_festival_dates = pd.DatetimeIndex(
     [
         "1959-10-10",
         "1960-10-28",

--- a/exchange_calendars/precomputed_exchange_calendar.py
+++ b/exchange_calendars/precomputed_exchange_calendar.py
@@ -3,7 +3,6 @@ from abc import abstractproperty
 
 import numpy as np
 import pandas as pd
-from pytz import UTC
 
 from .exchange_calendar import ExchangeCalendar
 
@@ -32,11 +31,11 @@ class PrecomputedExchangeCalendar(ExchangeCalendar):
 
     @property
     def bound_start(self) -> pd.Timestamp:
-        return pd.Timestamp(f"{self._earliest_precomputed_year}-01-01", tz=UTC)
+        return pd.Timestamp(f"{self._earliest_precomputed_year}-01-01")
 
     @property
     def bound_end(self) -> pd.Timestamp:
-        return pd.Timestamp(f"{self._latest_precomputed_year}-12-31", tz=UTC)
+        return pd.Timestamp(f"{self._latest_precomputed_year}-12-31")
 
     def _bound_start_error_msg(self, start: pd.Timestamp) -> str:
         return (

--- a/exchange_calendars/xkrx_holidays.py
+++ b/exchange_calendars/xkrx_holidays.py
@@ -14,7 +14,7 @@ from .pandas_extensions.korean_holiday import (
 
 # Original precomputed KRX holidays
 # that had been maintained formerly in exchange_calendar_xkrx.py.
-original_precomputed_krx_holidays = pd.to_datetime(
+original_precomputed_krx_holidays = pd.DatetimeIndex(
     [
         "1986-01-01",
         "1986-01-02",
@@ -540,7 +540,7 @@ original_precomputed_krx_holidays = pd.to_datetime(
 
 # Automatically generated holidays using /etc/update_xkrx_holidays.py script.
 # Note that there are some missing holidays compared to the original holidays.
-dumped_precomputed_krx_holidays = pd.to_datetime(
+dumped_precomputed_krx_holidays = pd.DatetimeIndex(
     [
         "1975-02-12",
         "1975-03-10",
@@ -1292,7 +1292,7 @@ krx_regular_holiday_rules = (
 # Theses are used for special offsets (30 minutes or 1 hour delay in schedule)
 # https://ko.wikipedia.org/wiki/%EC%97%B0%EB%8F%84%EB%B3%84_%EB%8C%80%ED%95%99%EC%88%98%ED%95%99%EB%8A%A5%EB%A0%A5%EC%8B%9C%ED%97%98
 
-precomputed_csat_days = pd.to_datetime(
+precomputed_csat_days = pd.DatetimeIndex(
     [
         "1993-08-20",  # https://www.hankyung.com/news/article/1993081702291                      0940~1140, 1320~1520 => 1010~1210, 1350~1550
         "1993-11-16",  # https://www.hankyung.com/news/article/1993111501631                      0940~1140, 1320~1520 => 1010~1210, 1350~1550

--- a/tests/test_always_open.py
+++ b/tests/test_always_open.py
@@ -24,7 +24,7 @@ class TestAlwaysOpenCalendar(ExchangeCalendarTestBase):
 
     def test_open_every_day(self, default_calendar_with_answers):
         cal, ans = default_calendar_with_answers
-        dates = pd.date_range(*ans.sessions_range, tz=UTC)
+        dates = pd.date_range(*ans.sessions_range)
         tm.assert_index_equal(cal.sessions, dates)
 
     def test_open_every_minute(self, calendars, answers, one_minute):

--- a/tests/test_asex_calendar.py
+++ b/tests/test_asex_calendar.py
@@ -128,14 +128,14 @@ class TestASEXCalendar(ExchangeCalendarTestBase):
         from 5:00PM to 5:20PM to close the time gap with Wall Street.
         """
         cal = default_calendar
-        close_time = cal.closes["2006-09-29"].tz_localize("UTC")
+        close_time = cal.closes["2006-09-29"]
         assert close_time == pd.Timestamp("2006-09-29 17:00", tz="Europe/Athens")
 
-        close_time = cal.closes["2008-09-26"].tz_localize("UTC")
+        close_time = cal.closes["2008-09-26"]
         assert close_time == pd.Timestamp("2008-09-26 17:00", tz="Europe/Athens")
 
-        close_time = cal.closes["2008-09-29"].tz_localize("UTC")
+        close_time = cal.closes["2008-09-29"]
         assert close_time == pd.Timestamp("2008-09-29 17:20", tz="Europe/Athens")
 
-        close_time = cal.closes["2008-09-30"].tz_localize("UTC")
+        close_time = cal.closes["2008-09-30"]
         assert close_time == pd.Timestamp("2008-09-30 17:20", tz="Europe/Athens")

--- a/tests/test_calendar_dispatcher.py
+++ b/tests/test_calendar_dispatcher.py
@@ -131,8 +131,8 @@ class CalendarDispatcherTestCase(TestCase):
         self.assertIsInstance(cal, ExchangeCalendar)
 
     def test_get_calendar_kwargs(self):
-        start = pd.Timestamp("2020-01-02", tz="UTC")
-        end = pd.Timestamp("2020-01-31", tz="UTC")
+        start = pd.Timestamp("2020-01-02")
+        end = pd.Timestamp("2020-01-31")
         cal = self.dispatcher.get_calendar("IEPA", start=start, end=end)
         self.assertEqual(cal.first_session, start)
         self.assertEqual(cal.last_session, end)
@@ -152,8 +152,8 @@ class CalendarDispatcherTestCase(TestCase):
             self.dispatcher.get_calendar("iepa_instance", side="right")
 
     def test_get_calendar_cache(self):
-        start = pd.Timestamp("2020-01-02", tz="UTC")
-        end = pd.Timestamp("2020-01-31", tz="UTC")
+        start = pd.Timestamp("2020-01-02")
+        end = pd.Timestamp("2020-01-31")
         cal = self.dispatcher.get_calendar("IEPA", start=start, end=end, side="right")
         cal2 = self.dispatcher.get_calendar("IEPA", start=start, end=end, side="right")
         self.assertIs(cal, cal2)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,5 @@
 import pandas as pd
-from pytz import UTC
 
 
 def T(x):
-    return pd.Timestamp(x, tz=UTC)
+    return pd.Timestamp(x)

--- a/tests/test_weekday_calendar.py
+++ b/tests/test_weekday_calendar.py
@@ -24,7 +24,7 @@ class TestWeekdayCalendar(ExchangeCalendarTestBase):
 
     def test_open_every_weekday(self, default_calendar_with_answers):
         cal, ans = default_calendar_with_answers
-        dates = pd.date_range(*ans.sessions_range, freq="B", tz=UTC)
+        dates = pd.date_range(*ans.sessions_range, freq="B")
         tm.assert_index_equal(cal.sessions, dates)
 
     def test_open_every_weekday_minute(self, calendars, answers, one_minute):

--- a/tests/test_xsgo_calendar.py
+++ b/tests/test_xsgo_calendar.py
@@ -1,6 +1,5 @@
 import pytest
 import pandas as pd
-from pytz import UTC
 
 from exchange_calendars.exchange_calendar_xsgo import XSGOExchangeCalendar
 from .test_exchange_calendar import ExchangeCalendarTestBase
@@ -171,7 +170,7 @@ class TestXSGOCalendar(ExchangeCalendarTestBase):
         early_closes_time = pd.Timedelta(hours=12, minutes=30)
         offset = pd.Timedelta(cal.close_offset, "D") + early_closes_time
         for date in early_closes:
-            early_close = cal.closes[date].tz_localize(UTC).tz_convert(tz)
+            early_close = cal.closes[date].tz_convert(tz)
             expected = pd.Timestamp(date, tz=tz) + offset
             assert early_close == expected
 
@@ -187,4 +186,4 @@ class TestXSGOCalendar(ExchangeCalendarTestBase):
         )
         cal = default_calendar
         for date, close in dates_closes:
-            cal.closes[date].tz_localize(UTC) == pd.Timestamp(close, tz=cal.tz)
+            cal.closes[date] == pd.Timestamp(close, tz=cal.tz)


### PR DESCRIPTION
Changes sessions to tz-naive.
Changes schedule times to UTC.

Also
- Adds typing to, adds doc to and renames parameters of:
  - some private `ExchangeCalendar` initialization methods.
  - some private `XKRXExchangeCalendar` initialization methods.
  - `pandas_utils.days_at_time`.

Change discussed in #42.
Contributes to v4 #61.