### PR TITLE
v4 dev: revises ` *window`, `bound*`, `default*` and prev/next session/minute methods.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,16 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v3.4.0
+  rev: v4.2.0
   hooks:
     - id: check-yaml
     - id: end-of-file-fixer
     - id: trailing-whitespace
 - repo: https://github.com/pycqa/flake8
-  rev: 3.9.1
+  rev: 4.0.1
   hooks:
     - id: flake8
 - repo: https://github.com/psf/black
-  rev: 21.4b2
+  rev: 22.3.0
   hooks:
     - id: black
       language_version: python

--- a/exchange_calendars/exchange_calendar.py
+++ b/exchange_calendars/exchange_calendar.py
@@ -1941,43 +1941,41 @@ class ExchangeCalendar(ABC):
         return self.minutes[slc]
 
     def minutes_window(
-        self, start_dt: TradingMinute, count: int, _parse: bool = True
+        self, minute: TradingMinute, count: int, _parse: bool = True
     ) -> pd.DatetimeIndex:
         """Return block of given size of consecutive trading minutes.
 
         Parameters
         ----------
-        start_dt
+        minute
             Minute representing the first (if `count` positive) or last
             (if `count` negative) minute of minutes window.
 
         count
-            Number of mintues to include in window in addition to
-                `start_dt` (i.e. 0 will return block of length 1 with
-                `start_dt` as only value).
-            Positive to return block of minutes from `start_dt`
-            Negative to return block of minutes to `start_dt`.
+            Number of mintues to include in window.
+            Positive to return a block of minutes from `minute`
+            Negative to return a block of minutes to `minute`.
         """
+        if not count:
+            raise ValueError("`count` cannot be 0.")
         if _parse:
-            start_dt = parse_trading_minute(self, start_dt, "start_dt")
+            minute = parse_trading_minute(self, minute, "minute")
 
-        start_idx = self._get_minute_idx(start_dt, _parse=False)
-        end_idx = start_idx + count
+        start_idx = self._get_minute_idx(minute, _parse=False)
+        end_idx = start_idx + count + (-1 if count > 0 else 1)
 
         if end_idx < 0:
             raise ValueError(
-                f"Minutes window cannot begin before the calendar's first"
-                f" trading minute ({self.first_minute}). `count`"
-                f" cannot be lower than {count - end_idx} for `start`"
-                f" '{start_dt}'."
+                f"Minutes window cannot begin before the calendar's first minute"
+                f" ({self.first_minute}). `count` cannot be lower than"
+                f" {count - end_idx} for `minute` '{minute}'."
             )
         elif end_idx >= len(self.minutes_nanos):
             raise ValueError(
-                f"Minutes window cannot end after the calendar's last"
-                f" trading minute ({self.last_minute}). `count`"
-                f" cannot be higher than"
-                f" {count - (end_idx - len(self.minutes_nanos) + 1)} for"
-                f" `start` '{start_dt}'."
+                f"Minutes window cannot end after the calendar's last minute"
+                f" ({self.last_minute}). `count` cannot be higher than"
+                f" {count - (end_idx - len(self.minutes_nanos) + 1)} for `minute`"
+                f" '{minute}'."
             )
         return self.minutes[min(start_idx, end_idx) : max(start_idx, end_idx) + 1]
 
@@ -2121,39 +2119,39 @@ class ExchangeCalendar(ABC):
         return self.break_starts[slc].notna().any()
 
     def sessions_window(
-        self, session_label: Session, count: int, _parse: bool = True
+        self, session: Session, count: int, _parse: bool = True
     ) -> pd.DatetimeIndex:
         """Return block of given size of consecutive sessions.
 
         Parameters
         ----------
-        session_label
+        session
             Session representing the first (if `count` positive) or last
             (if `count` negative) session of session window.
 
         count
-            Number of sessions to include in window in addition to
-                `session_label` (i.e. 0 will return window of length 1 with
-                `session_label` as only value).
-            Positive to return window of sessions from `session_label`
-            Negative to return window of sessions to `session_label`.
+            Number of sessions to include in window.
+            Positive to return window of sessions from `session`
+            Negative to return window of sessions to `session`.
         """
+        if not count:
+            raise ValueError("`count` cannot be 0.")
         if _parse:
-            session_label = parse_session(self, session_label, "session_label")
-        start_idx = self._get_session_idx(session_label, _parse=False)
-        end_idx = start_idx + count
+            session = parse_session(self, session, "session")
+        start_idx = self._get_session_idx(session, _parse=False)
+        end_idx = start_idx + count + (-1 if count > 0 else 1)
         if end_idx < 0:
             raise ValueError(
                 f"Sessions window cannot begin before the first calendar session"
                 f" ({self.first_session}). `count` cannot be lower than"
-                f" {count - end_idx} for `session` '{session_label}'."
+                f" {count - end_idx} for `session` '{session}'."
             )
         elif end_idx >= len(self.sessions):
             raise ValueError(
                 f"Sessions window cannot end after the last calendar session"
                 f" ({self.last_session}). `count` cannot be higher than"
                 f" {count - (end_idx - len(self.sessions) + 1)} for"
-                f" `session` '{session_label}'."
+                f" `session` '{session}'."
             )
         return self.sessions[min(start_idx, end_idx) : max(start_idx, end_idx) + 1]
 

--- a/exchange_calendars/exchange_calendar_aixk.py
+++ b/exchange_calendars/exchange_calendar_aixk.py
@@ -154,8 +154,8 @@ class AIXKExchangeCalendar(ExchangeCalendar):
 
     close_times = ((None, time(17, 00)),)
 
-    @property
-    def bound_start(self) -> pd.Timestamp:
+    @classmethod
+    def bound_start(cls) -> pd.Timestamp:
         return pd.Timestamp("2017-01-01")
 
     def _bound_start_error_msg(self, start: pd.Timestamp) -> str:

--- a/exchange_calendars/exchange_calendar_xbom.py
+++ b/exchange_calendars/exchange_calendar_xbom.py
@@ -402,7 +402,7 @@ precomputed_bse_holidays = pd.to_datetime(
         "2022-10-22",
         "2022-10-24",
         "2022-10-26",
-        "2022-11-08"
+        "2022-11-08",
     ]
 )
 
@@ -424,6 +424,6 @@ class XBOMExchangeCalendar(PrecomputedExchangeCalendar):
     open_times = ((None, time(9, 15)),)
     close_times = ((None, time(15, 30)),)
 
-    @property
-    def precomputed_holidays(self):
+    @classmethod
+    def precomputed_holidays(cls):
         return precomputed_bse_holidays

--- a/exchange_calendars/exchange_calendar_xhkg.py
+++ b/exchange_calendars/exchange_calendar_xhkg.py
@@ -286,6 +286,26 @@ class XHKGExchangeCalendar(PrecomputedExchangeCalendar):
         (pd.Timestamp("2011-03-07"), time(12, 00)),
     )
 
+    @classmethod
+    def precomputed_holidays(cls):
+        lunisolar_holidays = (
+            chinese_buddhas_birthday_dates,
+            chinese_lunar_new_year_dates,
+            day_after_mid_autumn_festival_dates,
+            double_ninth_festival_dates,
+            dragon_boat_festival_dates,
+            qingming_festival_dates,
+        )
+        return lunisolar_holidays
+
+    @classmethod
+    def _earliest_precomputed_year(cls) -> int:
+        return max(map(np.min, cls.precomputed_holidays())).year
+
+    @classmethod
+    def _latest_precomputed_year(cls) -> int:
+        return min(map(np.max, cls.precomputed_holidays())).year
+
     @property
     def regular_holidays(self):
         return HolidayCalendar(
@@ -305,26 +325,6 @@ class XHKGExchangeCalendar(PrecomputedExchangeCalendar):
                 boxing_day(observance=boxing_day_obs),
             ]
         )
-
-    @property
-    def precomputed_holidays(self):
-        lunisolar_holidays = (
-            chinese_buddhas_birthday_dates,
-            chinese_lunar_new_year_dates,
-            day_after_mid_autumn_festival_dates,
-            double_ninth_festival_dates,
-            dragon_boat_festival_dates,
-            qingming_festival_dates,
-        )
-        return lunisolar_holidays
-
-    @property
-    def _earliest_precomputed_year(self) -> int:
-        return max(map(np.min, self.precomputed_holidays)).year
-
-    @property
-    def _latest_precomputed_year(self) -> int:
-        return min(map(np.max, self.precomputed_holidays)).year
 
     @property
     def adhoc_holidays(self):

--- a/exchange_calendars/exchange_calendar_xkrx.py
+++ b/exchange_calendars/exchange_calendar_xkrx.py
@@ -130,12 +130,16 @@ class XKRXExchangeCalendar(PrecomputedExchangeCalendar):
             (None, pd.Timestamp("1998-12-06"), "1111110"),
         ]
 
-    @property
-    def _earliest_precomputed_year(self) -> int:
+    @classmethod
+    def precomputed_holidays(cls) -> list[pd.Timestamp]:
+        return precomputed_krx_holidays.tolist()
+
+    @classmethod
+    def _earliest_precomputed_year(cls) -> int:
         return 1956
 
-    @property
-    def _latest_precomputed_year(self) -> int:
+    @classmethod
+    def _latest_precomputed_year(cls) -> int:
         return 2050
 
     # KRX regular and precomputed adhoc holidays
@@ -143,10 +147,6 @@ class XKRXExchangeCalendar(PrecomputedExchangeCalendar):
     @property
     def regular_holidays(self):
         return HolidayCalendar(krx_regular_holiday_rules)
-
-    @property
-    def precomputed_holidays(self) -> pd.DatetimeIndex:
-        return precomputed_krx_holidays.tolist()
 
     # The first business day of each year:
     #  opening schedule is delayed by an hour.
@@ -401,6 +401,6 @@ class PrecomputedXKRXExchangeCalendar(PrecomputedExchangeCalendar):
     open_times = ((None, time(9)),)
     close_times = ((None, time(15, 30)),)
 
-    @property
-    def precomputed_holidays(self):
+    @classmethod
+    def precomputed_holidays(cls):
         return precomputed_krx_holidays

--- a/exchange_calendars/exchange_calendar_xses.py
+++ b/exchange_calendars/exchange_calendar_xses.py
@@ -404,6 +404,6 @@ class XSESExchangeCalendar(PrecomputedExchangeCalendar):
     open_times = ((None, time(9)),)
     close_times = ((None, time(17, 0)),)
 
-    @property
-    def precomputed_holidays(self):
+    @classmethod
+    def precomputed_holidays(cls):
         return precomputed_ses_holidays

--- a/exchange_calendars/exchange_calendar_xshg.py
+++ b/exchange_calendars/exchange_calendar_xshg.py
@@ -596,10 +596,10 @@ class XSHGExchangeCalendar(PrecomputedExchangeCalendar):
     break_end_times = ((None, time(13, 0)),)
     close_times = ((None, time(15, 0)),)
 
-    @property
-    def precomputed_holidays(self):
+    @classmethod
+    def precomputed_holidays(cls):
         return precomputed_shanghai_holidays
 
-    @property
-    def bound_start(self) -> pd.Timestamp:
+    @classmethod
+    def bound_start(cls) -> pd.Timestamp:
         return pd.Timestamp("1990-12-03")

--- a/exchange_calendars/exchange_calendar_xtks.py
+++ b/exchange_calendars/exchange_calendar_xtks.py
@@ -87,8 +87,8 @@ class XTKSExchangeCalendar(ExchangeCalendar):
     break_end_times = ((None, time(12, 30)),)
     close_times = ((None, time(15)),)
 
-    @property
-    def bound_start(self) -> pd.Timestamp:
+    @classmethod
+    def bound_start(cls) -> pd.Timestamp:
         # not tracking holiday info farther back than 1997
         return pd.Timestamp("1997-01-01")
 

--- a/exchange_calendars/precomputed_exchange_calendar.py
+++ b/exchange_calendars/precomputed_exchange_calendar.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from abc import abstractproperty
+from abc import abstractmethod
 
 import numpy as np
 import pandas as pd
@@ -13,40 +13,44 @@ class PrecomputedExchangeCalendar(ExchangeCalendar):
     are precomputed and hardcoded.
     """
 
-    @abstractproperty
-    def precomputed_holidays(self) -> pd.DatetimeIndex | list[pd.Timestamp]:
+    @abstractmethod
+    def precomputed_holidays(cls) -> pd.DatetimeIndex | list[pd.Timestamp]:
+        """Precomputed holidays.
+
+        Subclass should implement as a classmethod.
+        """
         raise NotImplementedError()
 
     @property
     def adhoc_holidays(self) -> pd.DatetimeIndex | list[pd.Timestamp]:
-        return self.precomputed_holidays
+        return self.precomputed_holidays()
 
-    @property
-    def _earliest_precomputed_year(self) -> int:
-        return np.min(self.precomputed_holidays).year
+    @classmethod
+    def _earliest_precomputed_year(cls) -> int:
+        return np.min(cls.precomputed_holidays()).year
 
-    @property
-    def _latest_precomputed_year(self) -> int:
-        return np.max(self.precomputed_holidays).year
+    @classmethod
+    def _latest_precomputed_year(cls) -> int:
+        return np.max(cls.precomputed_holidays()).year
 
-    @property
-    def bound_start(self) -> pd.Timestamp:
-        return pd.Timestamp(f"{self._earliest_precomputed_year}-01-01")
+    @classmethod
+    def bound_start(cls) -> pd.Timestamp:
+        return pd.Timestamp(f"{cls._earliest_precomputed_year()}-01-01")
 
-    @property
-    def bound_end(self) -> pd.Timestamp:
-        return pd.Timestamp(f"{self._latest_precomputed_year}-12-31")
+    @classmethod
+    def bound_end(cls) -> pd.Timestamp:
+        return pd.Timestamp(f"{cls._latest_precomputed_year()}-12-31")
 
     def _bound_start_error_msg(self, start: pd.Timestamp) -> str:
         return (
             f"The {self.name} holidays are only recorded back to the year"
-            f" {self._earliest_precomputed_year}, cannot instantiate the"
+            f" {self._earliest_precomputed_year()}, cannot instantiate the"
             f" {self.name} calendar from {start}."
         )
 
     def _bound_end_error_msg(self, end: pd.Timestamp) -> str:
         return (
             f"The {self.name} holidays are only recorded to the year"
-            f" {self._latest_precomputed_year}, cannot instantiate the"
+            f" {self._latest_precomputed_year()}, cannot instantiate the"
             f" {self.name} calendar through to {end}."
         )

--- a/tests/test_exchange_calendar.py
+++ b/tests/test_exchange_calendar.py
@@ -2696,7 +2696,8 @@ class ExchangeCalendarTestBase:
         # NB non-sessions handled by methods via parse_session
 
         # first session
-        with pytest.raises(ValueError):
+        match = "Requested session would fall before the calendar's first session"
+        with pytest.raises(errors.RequestedSessionOutOfBounds, match=match):
             f_prev(ans.first_session)
 
         # middle sessions (and m_prev for last session)
@@ -2705,7 +2706,8 @@ class ExchangeCalendarTestBase:
             assert f_prev(next_session) == session
 
         # last session
-        with pytest.raises(ValueError):
+        match = "Requested session would fall after the calendar's last session"
+        with pytest.raises(errors.RequestedSessionOutOfBounds, match=match):
             f_next(ans.last_session)
 
     def test_session_minutes(self, all_calendars_with_answers):
@@ -2924,7 +2926,8 @@ class ExchangeCalendarTestBase:
         last_min_plus_one = ans.last_minutes_plus_one[0]
         last_min_less_one = ans.last_minutes_less_one[0]
 
-        with pytest.raises(ValueError):
+        match = "Requested minute would fall before the calendar's first trading minute"
+        with pytest.raises(errors.RequestedMinuteOutOfBounds, match=match):
             f_prev(first_min)
         # minutes earlier than first_minute assumed handled via parse_timestamp
         assert f_next(first_min) == first_min_plus_one
@@ -2971,7 +2974,8 @@ class ExchangeCalendarTestBase:
 
             prev_last_min = last_min
 
-        with pytest.raises(ValueError):
+        match = "Requested minute would fall after the calendar's last trading minute"
+        with pytest.raises(errors.RequestedMinuteOutOfBounds, match=match):
             f_next(last_min)
         # minutes later than last_minute assumed handled via parse_timestamp
 

--- a/tests/test_exchange_calendar.py
+++ b/tests/test_exchange_calendar.py
@@ -2270,6 +2270,7 @@ class ExchangeCalendarTestBase:
                 calendar_cls(start=start, end=end)
 
     def test_bound_start(self, calendar_cls, start_bound, today):
+        assert calendar_cls.bound_start() == start_bound
         if start_bound is not None:
             cal = calendar_cls(start_bound, today)
             assert isinstance(cal, ExchangeCalendar)
@@ -2283,6 +2284,7 @@ class ExchangeCalendarTestBase:
             assert isinstance(cal, ExchangeCalendar)
 
     def test_bound_end(self, calendar_cls, end_bound, today):
+        assert calendar_cls.bound_end() == end_bound
         if end_bound is not None:
             cal = calendar_cls(today, end_bound)
             assert isinstance(cal, ExchangeCalendar)


### PR DESCRIPTION
v4 development (#61):
- Revises `ExchangeCalendar.*_window` methods to return windows of length `count` (instead of `count` + 1).
- Changes error raised when prev/next minute/session is out-of-bounds (now raises `Requested*OutOfBounds`).
- Changes `ExchangeCalendar` `bound*` and `default*` properties to class methods (related to #182).