### PR TITLE
v4 dev: Change default `side` to "left" and post v4 linting

### DIFF
--- a/exchange_calendars/exchange_calendar.py
+++ b/exchange_calendars/exchange_calendar.py
@@ -167,7 +167,7 @@ class ExchangeCalendar(ABC):
         Last calendar session will be `end`, if `end` is a session, or last
         session before `end`.
 
-    side : default: "both" ("left" for 24 hour calendars)
+    side : default: "left"
         Define which of session open/close and break start/end should
             be treated as a trading minute:
         "left" - treat session open and break_start as trading minutes,
@@ -287,9 +287,8 @@ class ExchangeCalendar(ABC):
         self,
         start: Date | None = None,
         end: Date | None = None,
-        side: Literal["left", "right", "both", "neither"] | None = None,
+        side: Literal["left", "right", "both", "neither"] = "left",
     ):
-        side = side if side is not None else self.default_side()
         if side not in self.valid_sides():
             raise ValueError(
                 f"`side` must be in {self.valid_sides()} although received as {side}."
@@ -701,14 +700,6 @@ class ExchangeCalendar(ABC):
             return ["left", "right"]
         else:
             return ["both", "left", "right", "neither"]
-
-    @classmethod
-    def default_side(cls) -> Literal["right", "both"]:
-        """Default `side` option."""
-        if cls.close_times == cls.open_times:
-            return "right"
-        else:
-            return "both"
 
     @property
     def side(self) -> Literal["left", "right", "both", "neither"]:

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ license_file = LICENSE
 [tool:pytest]
 addopts = -v --doctest-modules --durations=15
 
-testpaths = 
+testpaths =
     tests
     exchange_calendars/utils/pandas_utils.py
 
@@ -35,3 +35,11 @@ exclude =
     .git,
     __pycache__,
     versioneer.py
+
+[mypy]
+warn_unreachable = True
+warn_redundant_casts = True
+warn_unused_ignores = True
+strict_equality = True
+show_error_codes = True
+ignore_missing_imports = True

--- a/tests/test_calendar_helpers.py
+++ b/tests/test_calendar_helpers.py
@@ -413,8 +413,7 @@ class TestTradingIndex:
         """Dict of answers for tested calendars, key as name, value as Answers."""
         d = {}
         for name in self.calendar_names:
-            cal_cls = calendar_utils._default_calendar_factories[name]
-            d[name] = Answers(name, cal_cls.default_side())
+            d[name] = Answers(name, side="left")
         return d
 
     @pytest.fixture(scope="class")


### PR DESCRIPTION
v4 development (#61)

Changes default calendar side to "left" for all calendars (from "right" for 24h calendars and "both" for all others) (#181).

Selective linting of `exchange_calendar.py` (using mypy and pylint) post v4 changes.