### PR TITLE
Update resolving of __init__.__version__

### DIFF
--- a/exchange_calendars/__init__.py
+++ b/exchange_calendars/__init__.py
@@ -41,7 +41,24 @@ __all__ = [
     "ExchangeCalendar",
 ]
 
+__version__ = None
+
 from importlib.metadata import version
 
-__version__ = version("exchange_calendars")
+try:
+    # get version from installed package
+    __version__ = version("exchange_calendars")
+except ImportError:
+    pass
+
+if __version__ is None:
+    try:
+        # if package not installed, get version as set when package built
+        from ._version import version
+    except Exception:
+        # If package not installed and not built, leave __version__ as None
+        pass
+    else:
+        __version__ = version
+
 del version


### PR DESCRIPTION
Resolve `__init__.__version__` from `_version.py` if unable to read from installed package's metadata.

Fixes #213