### PR TITLE
BLD: Try using dependabot again

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
-  # reverted because dependabot can't ignore files
-  # - package-ecosystem: "pip" # See documentation for possible values
-  #   directory: "/etc" # Location of package manifests
-  #   schedule:
-  #     interval: "daily"
+  - package-ecosystem: "pip" # See documentation for possible values
+    directory: "/etc" # Location of package manifests
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Now that `requirements.txt` has gotten much simpler, I think we could try using dependabot again for automatically bumping the requirements.


Any objections @maread99 ?