### PR TITLE
ecal should use timezone naive date

### DIFF
--- a/exchange_calendars/ecal.py
+++ b/exchange_calendars/ecal.py
@@ -41,7 +41,7 @@ def _render_month(calendar, year, month, print_year):
     else:
         end = "{year}-{month}".format(year=year, month=month + 1)
 
-    days = pd.date_range(start, end, closed="left", tz="UTC")
+    days = pd.date_range(start, end, closed="left")
 
     title = months[month - 1]
     if print_year:


### PR DESCRIPTION
ecal CLI command gets ValueError because it uses timezone aware date.
Removed UTC.