### PR TITLE
Fix etc/make_exchange_calendar_test_csv.py

### DIFF
--- a/etc/make_exchange_calendar_test_csv.py
+++ b/etc/make_exchange_calendar_test_csv.py
@@ -53,14 +53,14 @@ if start_arg == "existing" or end_arg == "existing":
     )
 
 if start_arg == "existing":
-    start = df.index[0]
+    start = df.index[0].tz_localize(None)
 elif start_arg == "default":
     start = None
 else:
     start = start_arg
 
 if end_arg == "existing":
-    end = df.index[-1]
+    end = df.index[-1].tz_localize(None)
 elif end_arg == "default":
     end = None
 else:


### PR DESCRIPTION
`exchange_calendars` v4 made session labels timezone-naive. This PR fixes `etc/make_exchange_calendar_test_csv.py`, which currently fails when requesting calendars with date ranges taken from the existing output, because they have an explicit timezone set.