### PR TITLE
Revert (partially) release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Install from test and test running
       run: |
         echo "Will wait 10s" && sleep 10s
-        pip install --index-url https://test.pypi.org/simple exchange_calendars==${{ github.ref_name }}
+        pip install --extra-index-url https://test.pypi.org/simple exchange_calendars==${{ github.ref_name }}
         python -c 'import exchange_calendars;print(exchange_calendars.__version__)'
         pip uninstall -y exchange_calendars
 


### PR DESCRIPTION
Reverts release workflow to pass --extra-index-url in order that pip can locate dependencies.