### PR TITLE
Simple file cache for calendars, avoiding expensive ops

### DIFF
--- a/exchange_calendars/calendar_utils.py
+++ b/exchange_calendars/calendar_utils.py
@@ -61,6 +61,9 @@ from .exchange_calendar_xwbo import XWBOExchangeCalendar
 from .us_futures_calendar import QuantopianUSFuturesCalendar
 from .weekday_calendar import WeekdayCalendar
 
+import appdirs, os, pickle
+import datetime as _dt
+
 _default_calendar_factories = {
     # Exchange calendars.
     "AIXK": AIXKExchangeCalendar,
@@ -175,6 +178,24 @@ class ExchangeCalendarDispatcher(object):
         # key: factory name, value: (calendar, dict of calendar kwargs)
         self._factory_output_cache: dict(str, tuple(ExchangeCalendar, dict)) = {}
 
+    def _get_cal_cache_fp(self, name):
+        cache_fn = "calendar-"+name+".pkl"
+        cache_dp = os.path.join(appdirs.user_cache_dir(), "py-exchange_calendars")
+        return os.path.join(cache_dp, cache_fn)
+
+    def _send_cal_to_cache(self, calendar, name: str, **kwargs):
+        self._factory_output_cache[name] = (calendar, kwargs)
+
+        pkl_data = {}
+        pkl_data["calendar"] = calendar
+        pkl_data["kwargs"] = kwargs
+        cache_fp = self._get_cal_cache_fp(name)
+        cache_dp = os.path.dirname(cache_fp)
+        if not os.path.isdir(cache_dp):
+            os.makedirs(cache_dp)
+        with open(cache_fp, 'wb') as f:
+            pickle.dump(pkl_data, f, 4)
+
     def _fabricate(self, name: str, **kwargs) -> ExchangeCalendar:
         """Fabricate calendar with `name` and `**kwargs`."""
         try:
@@ -182,7 +203,7 @@ class ExchangeCalendarDispatcher(object):
         except KeyError as e:
             raise InvalidCalendarName(calendar_name=name) from e
         calendar = factory(**kwargs)
-        self._factory_output_cache[name] = (calendar, kwargs)
+        self._send_cal_to_cache(calendar, name, **kwargs)
         return calendar
 
     def _get_cached_factory_output(
@@ -193,11 +214,27 @@ class ExchangeCalendarDispatcher(object):
         Return None if `name` not in cache or `name` in cache although
         calendar got with kwargs other than `**kwargs`.
         """
+        # First check memory cache:
         calendar, calendar_kwargs = self._factory_output_cache.get(name, (None, None))
         if calendar is not None and calendar_kwargs == kwargs:
             return calendar
-        else:
-            return None
+
+        # Next check local file cache:
+        cache_fp = self._get_cal_cache_fp(name)
+        if os.path.isfile(cache_fp):
+            moddt = _dt.datetime.fromtimestamp(os.path.getmtime(cache_fp))
+            # Additional condition that file created in last 24 hours
+            if (_dt.datetime.now()-moddt) < _dt.timedelta(days=1):
+                with open(cache_fp, 'rb') as f:
+                    pkl_data = pickle.load(f)
+                    if pkl_data["kwargs"] == kwargs:
+                        calendar = pkl_data["calendar"]
+                        if not name in self._factory_output_cache:
+                            self._factory_output_cache[name] = (calendar, kwargs)
+                        return calendar
+
+        return None
+
 
     def get_calendar(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
+    "appdirs",
     "numpy",
     "pandas >= 1.1",
     "pyluach",


### PR DESCRIPTION
Annoyed by long runtimes of creating large calendars, I've introduced a simple file cache. Write fabricated calendars to users` cache; then search cache for matches before searching the dict.

If cached calendar older than 24 hours then it is ignored & eventually overwritten. Stops cached calendars never updating.

Uses `appdirs` module to get user cache folder path, so should be cross-platform. Specifically: `user_cache_dir()` - their README provides actual path for each platform: https://pypi.org/project/appdirs

**Benchmark**
My use case is creating full calendars across multiple exchanges. Was ~10 seconds, now 0.4 seconds (once cache initialised).
```
import exchange_calendars as xcal
from time import perf_counter

exchanges = ["XNYS", "XTSE", "XLON", "XAMS", "XTAE", "XASX", "XNZE"]

t1 = perf_counter()
for e in exchanges:
	cal = xcal.get_calendar(e,start=1950)
t = perf_counter()-t1
if t < 2:
	print("loading from file cache: {:.2f}s".format(t))
else:
	print("creating from scratch: {:.2f}s".format(t))

t1 = perf_counter()
for e in exchanges:
	cal = xcal.get_calendar(e,start=1950)
print("loading from dict cache: {:.2f}s".format(perf_counter()-t1))
```
Output:
- first pass

> creating from scratch: 11.22s
> loading from dict cache: 0.00s

- second pass

> loading from file cache: 0.42s
> loading from dict cache: 0.00s

Cache contents after run:

> ls ~/.cache/py-exchange_calendars  
> calendar-XAMS.pkl  calendar-XLON.pkl  calendar-XNZE.pkl  calendar-XTSE.pkl
> calendar-XASX.pkl  calendar-XNYS.pkl  calendar-XTAE.pkl