### PR TITLE
Add ad-hoc holidays for XIST trading suspension due to earthquake.

### DIFF
--- a/exchange_calendars/exchange_calendar_xist.py
+++ b/exchange_calendars/exchange_calendar_xist.py
@@ -151,6 +151,11 @@ class XISTExchangeCalendar(ExchangeCalendar):
             pd.Timestamp("2004-12-30"),  # Closure for redenomination
             pd.Timestamp("2004-12-31"),  # Closure for redenomination
             pd.Timestamp("2006-01-13"),  # Eid al Adha extra holiday
+            pd.Timestamp("2023-02-08"),  # Trade suspension after earthquake
+            pd.Timestamp("2023-02-09"),  # Trade suspension after earthquake
+            pd.Timestamp("2023-02-10"),  # Trade suspension after earthquake
+            pd.Timestamp("2023-02-13"),  # Trade suspension after earthquake
+            pd.Timestamp("2023-02-14"),  # Trade suspension after earthquake
         ]
 
         return list(

--- a/tests/test_xist_calendar.py
+++ b/tests/test_xist_calendar.py
@@ -48,6 +48,11 @@ class TestXISTCalendar(ExchangeCalendarTestBase):
             "2003-11-24",  # Eid al Fitr extra holiday
             "2003-11-28",  # Eid al Fitr extra holiday
             "2006-01-13",  # Eid al Adha extra holiday
+            "2023-02-08",  # Trade suspension after earthquake
+            "2023-02-09",  # Trade suspension after earthquake
+            "2023-02-10",  # Trade suspension after earthquake
+            "2023-02-13",  # Trade suspension after earthquake
+            "2023-02-14",  # Trade suspension after earthquake
         ]
 
     @pytest.fixture


### PR DESCRIPTION
Added the days that the exchange is now closed as ad-hoc holidays; see [Bloomberg article](https://www.bloomberg.com/news/articles/2023-02-08/turkey-suspends-trading-in-stock-market-as-rout-deepened).

This closes #283.