### PR TITLE
Add XNAS calendar alias

### DIFF
--- a/exchange_calendars/calendar_utils.py
+++ b/exchange_calendars/calendar_utils.py
@@ -126,6 +126,7 @@ _default_calendar_aliases = {
     "NYSE": "XNYS",
     "NASDAQ": "XNYS",
     "BATS": "XNYS",
+    "XNAS": "XNYS",
     "FWB": "XFRA",
     "LSE": "XLON",
     "TSX": "XTSE",


### PR DESCRIPTION
Add a `XNAS` alias that represents NASDAQ which has the same calendar as XNYS. The `XNAS` mic is a common representation for NASDAQ: see e.g: https://en.wikipedia.org/wiki/Market_Identifier_Code and http://www.iotafinance.com/en/Overview-operating-MIC-code-XNAS.html

