### PR TITLE
Updates for pandas 2.1.0

### DIFF
--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -10,7 +10,7 @@ numpy==1.25.2
     # via
     #   exchange-calendars (pyproject.toml)
     #   pandas
-pandas==2.0.3
+pandas==2.1.0
     # via exchange-calendars (pyproject.toml)
 pyluach==2.2.0
     # via exchange-calendars (pyproject.toml)

--- a/etc/requirements_dev.txt
+++ b/etc/requirements_dev.txt
@@ -6,7 +6,7 @@
 #
 attrs==23.1.0
     # via hypothesis
-build==0.10.0
+build==1.0.0
     # via pip-tools
 click==8.1.7
     # via pip-tools
@@ -23,8 +23,10 @@ execnet==2.0.2
     # via pytest-xdist
 flake8==6.1.0
     # via exchange-calendars (pyproject.toml)
-hypothesis==6.82.6
+hypothesis==6.84.0
     # via exchange-calendars (pyproject.toml)
+importlib-metadata==6.8.0
+    # via build
 iniconfig==2.0.0
     # via pytest
 korean-lunar-calendar==0.3.1
@@ -39,11 +41,11 @@ packaging==23.1
     # via
     #   build
     #   pytest
-pandas==2.0.3
+pandas==2.1.0
     # via exchange-calendars (pyproject.toml)
 pip-tools==7.3.0
     # via exchange-calendars (pyproject.toml)
-pluggy==1.2.0
+pluggy==1.3.0
     # via pytest
 py-cpuinfo==9.0.0
     # via pytest-benchmark
@@ -55,7 +57,7 @@ pyluach==2.2.0
     # via exchange-calendars (pyproject.toml)
 pyproject-hooks==1.0.0
     # via build
-pytest==7.4.0
+pytest==7.4.1
     # via
     #   exchange-calendars (pyproject.toml)
     #   pytest-benchmark
@@ -80,6 +82,7 @@ tomli==2.0.1
     # via
     #   build
     #   pip-tools
+    #   pyproject-hooks
     #   pytest
 toolz==0.12.0
     # via exchange-calendars (pyproject.toml)
@@ -87,6 +90,8 @@ tzdata==2023.3
     # via pandas
 wheel==0.41.2
     # via pip-tools
+zipp==3.16.2
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/etc/requirements_minpandas.txt
+++ b/etc/requirements_minpandas.txt
@@ -10,7 +10,7 @@
 #
 attrs==23.1.0
     # via hypothesis
-build==0.10.0
+build==1.0.0
     # via pip-tools
 click==8.1.7
     # via pip-tools
@@ -27,8 +27,10 @@ execnet==2.0.2
     # via pytest-xdist
 flake8==6.1.0
     # via exchange-calendars (pyproject.toml)
-hypothesis==6.82.6
+hypothesis==6.84.0
     # via exchange-calendars (pyproject.toml)
+importlib-metadata==6.8.0
+    # via build
 iniconfig==2.0.0
     # via pytest
 korean-lunar-calendar==0.3.1
@@ -47,7 +49,7 @@ pandas==1.5.0
     # via exchange-calendars (pyproject.toml)
 pip-tools==7.3.0
     # via exchange-calendars (pyproject.toml)
-pluggy==1.2.0
+pluggy==1.3.0
     # via pytest
 py-cpuinfo==9.0.0
     # via pytest-benchmark
@@ -59,7 +61,7 @@ pyluach==2.2.0
     # via exchange-calendars (pyproject.toml)
 pyproject-hooks==1.0.0
     # via build
-pytest==7.4.0
+pytest==7.4.1
     # via
     #   exchange-calendars (pyproject.toml)
     #   pytest-benchmark
@@ -84,11 +86,14 @@ tomli==2.0.1
     # via
     #   build
     #   pip-tools
+    #   pyproject-hooks
     #   pytest
 toolz==0.12.0
     # via exchange-calendars (pyproject.toml)
 wheel==0.41.2
     # via pip-tools
+zipp==3.16.2
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/exchange_calendars/exchange_calendar.py
+++ b/exchange_calendars/exchange_calendar.py
@@ -926,12 +926,12 @@ class ExchangeCalendar(ABC):
     @property
     def first_session_open(self) -> pd.Timestamp:
         """Open time of calendar's first session."""
-        return self.opens[0]
+        return self.opens.iloc[0]
 
     @property
     def last_session_close(self) -> pd.Timestamp:
         """Close time of calendar's last session."""
-        return self.closes[-1]
+        return self.closes.iloc[-1]
 
     @property
     def first_minute(self) -> pd.Timestamp:
@@ -1522,7 +1522,7 @@ class ExchangeCalendar(ABC):
         try:
             idx = next_divider_idx(self.opens_nanos, minute.value)
         except IndexError:
-            if minute >= self.opens[-1]:
+            if minute >= self.opens.iloc[-1]:
                 raise ValueError(
                     "Minute cannot be the last open or later (received `minute`"
                     f" parsed as '{minute}'.)"
@@ -1553,7 +1553,7 @@ class ExchangeCalendar(ABC):
         try:
             idx = next_divider_idx(self.closes_nanos, minute.value)
         except IndexError:
-            if minute == self.closes[-1]:
+            if minute == self.closes.iloc[-1]:
                 raise ValueError(
                     "Minute cannot be the last close (received `minute` parsed as"
                     f" '{minute}'.)"
@@ -1583,7 +1583,7 @@ class ExchangeCalendar(ABC):
         try:
             idx = previous_divider_idx(self.opens_nanos, minute.value)
         except ValueError:
-            if minute == self.opens[0]:
+            if minute == self.opens.iloc[0]:
                 raise ValueError(
                     "Minute cannot be the first open (received `minute` parsed as"
                     f" '{minute}'.)"
@@ -1614,7 +1614,7 @@ class ExchangeCalendar(ABC):
         try:
             idx = previous_divider_idx(self.closes_nanos, minute.value)
         except ValueError:
-            if minute <= self.closes[0]:
+            if minute <= self.closes.iloc[0]:
                 raise ValueError(
                     "Minute cannot be the first close or earlier (received"
                     f" `minute` parsed as '{minute}'.)"

--- a/exchange_calendars/exchange_calendar_xbud.py
+++ b/exchange_calendars/exchange_calendar_xbud.py
@@ -13,7 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from datetime import time, timedelta
+from __future__ import annotations
+
+import datetime
 
 from pandas.tseries.holiday import Easter, EasterMonday, Holiday
 from pandas.tseries.offsets import Day
@@ -31,58 +33,66 @@ from .common_holidays import (
 from .exchange_calendar import THURSDAY, TUESDAY, HolidayCalendar, ExchangeCalendar
 
 
-def four_day_weekend(dt, include_mon: bool = True, include_fri: bool = True):
+ONE_DAY = datetime.timedelta(1)
+
+
+def bridge_mon(dt: datetime.datetime) -> datetime.datetime | None:
+    """Define Monday as holiday if Tuesday is a holiday.
+
+    If a holiday falls on a Tuesday an extra holiday is observed on Monday
+    to create a three day weekend.
     """
-    Custom observance function as for almost all holidays in the XBUD calendar,
-    if the holiday falls on a Tuesday the previous Monday also becomes a holiday,
-    and if the holiday falls on a Thursday the following Friday also becomes a holiday.
+    return dt - ONE_DAY if dt.weekday() == TUESDAY else None
 
-    Parameters
-    ----------
-    dt : datetime
-         Unadjusted raw holiday datetimes
-    include_mon : boolean
-         If holiday falls on a Tuesday, previous Monday becomes a holiday.
-    include_fri : boolean
-         If holiday falls on a Thursday, following Friday becomes a holiday.
+
+def bridge_fri(dt: datetime.datetime) -> datetime.datetime | None:
+    """Define Friday as holiday if Thrusday is a holiday.
+
+    If a holiday falls on a Thursday an extra holiday is observed on Friday
+    to create a three day weekend.
     """
-    extras = []
-    if include_mon:
-        extras.append(dt[dt.weekday == TUESDAY] - timedelta(1))  # mv Tues back one day
-    if include_fri:
-        # mv Thurs ahead one day
-        extras.append(dt[dt.weekday == THURSDAY] + timedelta(1))
-    return dt.append(extras)
+    return dt + ONE_DAY if dt.weekday() == THURSDAY else None
 
 
-NewYearsDay = new_years_day(observance=four_day_weekend)
+NewYearsDayExtraMon = new_years_day(observance=bridge_mon)
+NewYearsDayExtraFri = new_years_day(observance=bridge_fri)
 
-NationalHoliday1 = Holiday("National Day", month=3, day=15, observance=four_day_weekend)
+NationalHoliday1 = Holiday("National Day", month=3, day=15)
+NationalHoliday1ExtraMon = Holiday(
+    "National Day extra Monday", month=3, day=15, observance=bridge_mon
+)
+NationalHoliday1ExtraFri = Holiday(
+    "National Day extra Friday", month=3, day=15, observance=bridge_fri
+)
 
 # Need custom start year so can't use pandas GoodFriday
 GoodFriday = Holiday(
     "Good Friday", month=1, day=1, offset=[Easter(), Day(-2)], start_date="2012"
 )
 
-LabourDay = european_labour_day(observance=four_day_weekend)
+LabourDayExtraMon = european_labour_day(observance=bridge_mon)
+LabourDayExtraFri = european_labour_day(observance=bridge_fri)
 
 WhitMonday = whit_monday()
 
-StStephensDay = Holiday(
-    "St. Stephen's Day",
-    month=8,
-    day=20,
-    observance=four_day_weekend,
+StStephensDay = Holiday("St. Stephen's Day", month=8, day=20)
+StStephensDayExtraMon = Holiday(
+    "St. Stephen's Day extra Monday", month=8, day=20, observance=bridge_mon
+)
+StStephensDayExtraFri = Holiday(
+    "St. Stephen's Day extra Friday", month=8, day=20, observance=bridge_fri
 )
 
-NationalHoliday2 = Holiday(
-    "National Day",
-    month=10,
-    day=23,
-    observance=four_day_weekend,
+NationalHoliday2 = Holiday("National Day", month=10, day=23)
+NationalHoliday2ExtraMon = Holiday(
+    "National Day extra Monday", month=10, day=23, observance=bridge_mon
+)
+NationalHoliday2ExtraFri = Holiday(
+    "National Day extra Friday", month=10, day=23, observance=bridge_fri
 )
 
-AllSaintsDay = all_saints_day(observance=four_day_weekend)
+AllSaintsDayExtraMon = all_saints_day(observance=bridge_mon)
+AllSaintsDayExtraFri = all_saints_day(observance=bridge_fri)
 
 # Christmas Eve does not follow the four day weekend rule
 ChristmasEve = christmas_eve()
@@ -92,25 +102,17 @@ ChristmasDay = christmas()
 # XBUD always has a holiday for the second day of Christmas (26th),
 # but starting in 2013 if the 26th falls on a Thursday then the
 # 27th (Friday) is also taken off
-SecondDayOfChristmas = Holiday(
-    "Second Day of Christmas (w/ no added Friday off)",
-    month=12,
-    day=26,
-    end_date="2013",
-)
-
-SecondDayOfChristmasAddFriday = Holiday(
-    "Second Day of Christmas (w/ added Friday off)",
+SecondDayOfChristmas = Holiday("Second Day of Christmas", month=12, day=26)
+SecondDayOfChristmasExtraFri = Holiday(
+    "Second Day of Christmas extra Friday",
     month=12,
     day=26,
     start_date="2013",
-    # Don't apply the rule here where the previous Monday also becomes a holiday if this
-    # falls onto a Tuesday.
-    # Rationale: The previous Monday in this case is Christmas which is already defined
-    # as a holiday above. Apply the other rule where the following Friday becomes a
-    # holiday if it falls onto a Thursday as usual.
-    observance=lambda dt: four_day_weekend(dt, include_mon=False, include_fri=True),
+    observance=bridge_fri,
 )
+# SecondDayOfChristmas unnecessary to bridge_mon as if second day of christmas
+# is a tuesday then monday will already be a holiday (Chirstmas Day)
+
 
 # Starting in 2011, New Year's Eve is observed as a holiday every year.
 # In some cases pre-2011, the 31st becomes a holiday due to the four day
@@ -150,27 +152,39 @@ class XBUDExchangeCalendar(ExchangeCalendar):
 
     tz = timezone("Europe/Budapest")
 
-    open_times = ((None, time(9)),)
+    open_times = ((None, datetime.time(9)),)
 
-    close_times = ((None, time(17, 00)),)
+    close_times = ((None, datetime.time(17, 00)),)
 
     @property
     def regular_holidays(self):
         return HolidayCalendar(
             [
-                NewYearsDay,
+                new_years_day(),
+                NewYearsDayExtraMon,
+                NewYearsDayExtraFri,
                 NationalHoliday1,
+                NationalHoliday1ExtraMon,
+                NationalHoliday1ExtraFri,
                 GoodFriday,
                 EasterMonday,
-                LabourDay,
+                european_labour_day(),
+                LabourDayExtraMon,
+                LabourDayExtraFri,
                 WhitMonday,
                 StStephensDay,
+                StStephensDayExtraMon,
+                StStephensDayExtraFri,
                 NationalHoliday2,
-                AllSaintsDay,
+                NationalHoliday2ExtraMon,
+                NationalHoliday2ExtraFri,
+                all_saints_day(),
+                AllSaintsDayExtraMon,
+                AllSaintsDayExtraFri,
                 ChristmasEve,
                 ChristmasDay,
                 SecondDayOfChristmas,
-                SecondDayOfChristmasAddFriday,
+                SecondDayOfChristmasExtraFri,
                 NewYearsEve,
             ]
         )

--- a/exchange_calendars/exchange_calendar_xbud.py
+++ b/exchange_calendars/exchange_calendar_xbud.py
@@ -40,7 +40,7 @@ def bridge_mon(dt: datetime.datetime) -> datetime.datetime | None:
     """Define Monday as holiday if Tuesday is a holiday.
 
     If a holiday falls on a Tuesday an extra holiday is observed on Monday
-    to create a three day weekend.
+    to bridge the weekend and the official holiday.
     """
     return dt - ONE_DAY if dt.weekday() == TUESDAY else None
 
@@ -49,7 +49,7 @@ def bridge_fri(dt: datetime.datetime) -> datetime.datetime | None:
     """Define Friday as holiday if Thrusday is a holiday.
 
     If a holiday falls on a Thursday an extra holiday is observed on Friday
-    to create a three day weekend.
+    to bridge the weekend and the official holiday.
     """
     return dt + ONE_DAY if dt.weekday() == THURSDAY else None
 

--- a/exchange_calendars/exchange_calendar_xbue.py
+++ b/exchange_calendars/exchange_calendar_xbue.py
@@ -13,7 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from datetime import time, timedelta
+from __future__ import annotations
+
+import datetime
 from itertools import chain
 
 import pandas as pd
@@ -39,7 +41,7 @@ from .exchange_calendar import (
 )
 
 
-def nearest_monday(dt):
+def nearest_monday(dt: datetime.datetime) -> datetime.datetime:
     """
     If a holiday falls on Tuesday or Wednesday, it is observed on the
     previous Monday.  If it falls on Thursday, Friday or a weekend,
@@ -48,29 +50,29 @@ def nearest_monday(dt):
     day = dt.weekday()
 
     if day in (MONDAY, TUESDAY, WEDNESDAY):
-        return dt - timedelta(day)
+        return dt - datetime.timedelta(day)
 
     while dt.weekday() != MONDAY:
-        dt += timedelta(1)
+        dt += datetime.timedelta(1)
 
     return dt
 
 
-def cultural_diversity_observance(holidays):
+def cultural_diversity_observance(dt: datetime.datetime) -> datetime.datetime | None:
     """
     Apply the nearest monday rule, and also exclude 2012 (Day of
     Respect for Cultural Diversity breaks the nearest monday rule
     in 2012).
     """
-    holidays = pd.to_datetime(holidays.map(nearest_monday))
-    return holidays[holidays.year != 2012]
+    hol = nearest_monday(dt)
+    return hol if hol.year != 2012 else None
 
 
-def not_2018(holidays):
+def not_2018(dt: datetime.datetime) -> datetime.datetime | None:
     """
     Exclude the year 2018 from the holiday list.
     """
-    return holidays[holidays.year != 2018]
+    return dt if dt.year != 2018 else None
 
 
 NewYearsDay = new_years_day()
@@ -252,12 +254,12 @@ class XBUEExchangeCalendar(ExchangeCalendar):
 
     tz = timezone("America/Argentina/Buenos_Aires")
 
-    open_times = ((None, time(11)),)
+    open_times = ((None, datetime.time(11)),)
 
-    close_times = ((None, time(17, 00)),)
+    close_times = ((None, datetime.time(17, 00)),)
 
     # TODO: Verify early close time
-    regular_early_close = time(13)
+    regular_early_close = datetime.time(13)
 
     @property
     def regular_holidays(self):

--- a/exchange_calendars/exchange_calendar_xmos.py
+++ b/exchange_calendars/exchange_calendar_xmos.py
@@ -13,10 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from datetime import time
+from __future__ import annotations
+
+import datetime
 from itertools import chain
 
-import pandas as pd
 from pandas.tseries.holiday import Holiday, weekend_to_monday
 from pytz import timezone
 
@@ -24,35 +25,27 @@ from .common_holidays import european_labour_day, new_years_day, new_years_eve
 from .exchange_calendar import WEEKDAYS, HolidayCalendar, ExchangeCalendar
 
 
-def new_years_eve_observance(holidays):
+def new_years_eve_observance(dt: datetime.datetime) -> datetime.datetime | None:
     # For some reason New Year's Eve was not a holiday these years.
-    holidays = holidays[(holidays.year != 2008) & (holidays.year != 2009)]
-
-    return pd.to_datetime([weekend_to_monday(day) for day in holidays])
+    return None if dt.year in [2008, 2009] else weekend_to_monday(dt)
 
 
-def new_years_holiday_observance(holidays):
+def new_years_holiday_observance(dt: datetime.datetime) -> datetime.datetime | None:
     # New Year's Holiday did not follow the next-non-holiday rule in 2016.
-    holidays = holidays[(holidays.year != 2016)]
-
-    return pd.to_datetime([weekend_to_monday(day) for day in holidays])
+    return None if dt.year == 2016 else weekend_to_monday(dt)
 
 
-def orthodox_christmas_observance(holidays):
+def orthodox_christmas_observance(dt: datetime.datetime) -> datetime.datetime | None:
     # Orthodox Christmas did not follow the next-non-holiday rule these years.
-    holidays = holidays[(holidays.year != 2012) & (holidays.year != 2017)]
-
-    return pd.to_datetime([weekend_to_monday(day) for day in holidays])
+    return None if dt.year in [2012, 2017] else weekend_to_monday(dt)
 
 
-def defender_of_fatherland_observance(holidays):
+def defender_of_fatherland_observance(
+    dt: datetime.datetime,
+) -> datetime.datetime | None:
     # Defender of the Fatherland Day did not follow the next-non-holiday rule
     # these years.
-    holidays = holidays[
-        (holidays.year != 2013) & (holidays.year != 2014) & (holidays.year != 2019)
-    ]
-
-    return pd.to_datetime([weekend_to_monday(day) for day in holidays])
+    return None if dt.year in [2013, 2014, 2019] else weekend_to_monday(dt)
 
 
 NewYearsDay = new_years_day(observance=weekend_to_monday)
@@ -258,9 +251,9 @@ class XMOSExchangeCalendar(ExchangeCalendar):
 
     tz = timezone("Europe/Moscow")
 
-    open_times = ((None, time(10)),)
+    open_times = ((None, datetime.time(10)),)
 
-    close_times = ((None, time(18, 45)),)
+    close_times = ((None, datetime.time(18, 45)),)
 
     @property
     def regular_holidays(self):

--- a/exchange_calendars/exchange_calendar_xphs.py
+++ b/exchange_calendars/exchange_calendar_xphs.py
@@ -13,7 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from datetime import time
+from __future__ import annotations
+
+import datetime
 from itertools import chain
 
 import pandas as pd
@@ -33,13 +35,13 @@ from .lunisolar_holidays import chinese_lunar_new_year_dates
 from .exchange_calendar import FRIDAY, HolidayCalendar, ExchangeCalendar
 
 
-def only_friday(dt):
+def only_friday(dt: datetime.datetime) -> datetime.datetime | None:
     """
     Only keeps the holidays that fall on a Friday.  Useful
     for defining holidays that add a Friday to make a 4-day weekend
     when falling on a Thursday.
     """
-    return dt[dt.weekday == FRIDAY]
+    return dt if dt.weekday() == FRIDAY else None
 
 
 # All pre-2011 holidays are pre-computed, so we define Holidays starting
@@ -193,9 +195,9 @@ class XPHSExchangeCalendar(ExchangeCalendar):
 
     tz = timezone("Asia/Manila")
 
-    open_times = ((None, time(9, 30)),)
+    open_times = ((None, datetime.time(9, 30)),)
 
-    close_times = ((None, time(15, 30)),)
+    close_times = ((None, datetime.time(15, 30)),)
 
     @property
     def regular_holidays(self):

--- a/exchange_calendars/exchange_calendar_xsgo.py
+++ b/exchange_calendars/exchange_calendar_xsgo.py
@@ -13,7 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from datetime import time, timedelta
+from __future__ import annotations
+
+import datetime
 
 import pandas as pd
 from pandas.tseries.holiday import Easter, GoodFriday, Holiday
@@ -44,7 +46,7 @@ from .exchange_calendar import (
 )
 
 
-def nearest_monday(dt):
+def nearest_monday(dt: datetime.datetime) -> datetime.datetime:
     """
     If the holiday falls on a Saturday, Sunday or Monday then the date is
     unchanged (Sat/Sun observances are not made up), otherwise use the closest
@@ -53,13 +55,13 @@ def nearest_monday(dt):
     day = dt.weekday()
 
     if day in (TUESDAY, WEDNESDAY, THURSDAY):
-        return dt - timedelta(day - MONDAY)
+        return dt - datetime.timedelta(day - MONDAY)
     elif day == FRIDAY:
-        return dt + timedelta(3)
+        return dt + datetime.timedelta(3)
     return dt
 
 
-def tuesday_and_wednesday_to_friday(dt):
+def tuesday_and_wednesday_to_friday(dt: datetime.datetime):
     """
     If Evangelical Church Day (Halloween) falls on a Tuesday, it is observed
     the preceding Friday. If it falls on a Wednesday, it is observed the next
@@ -68,19 +70,19 @@ def tuesday_and_wednesday_to_friday(dt):
     day = dt.weekday()
 
     if day == TUESDAY:
-        return dt - timedelta(4)
+        return dt - datetime.timedelta(4)
     elif day == WEDNESDAY:
-        return dt + timedelta(2)
+        return dt + datetime.timedelta(2)
     return dt
 
 
-def not_2010(holidays):
+def not_2010(dt: datetime.datetime) -> datetime.datetime | None:
     """
     In 2010 Independence Day fell on a Saturday. Normally this would mean that
     Friday is a half day, but instead it is a full day off, so we need to
     exclude it from the usual half day rules.
     """
-    return holidays[holidays.year != 2010]
+    return None if dt.year == 2010 else dt
 
 
 NewYearsDay = new_years_day()
@@ -205,9 +207,9 @@ class XSGOExchangeCalendar(ExchangeCalendar):
     name = "XSGO"
     tz = timezone("America/Santiago")
 
-    open_times = ((None, time(9, 30)),)
-    early_close_1230 = time(12, 30)
-    early_close_130 = time(13, 30)
+    open_times = ((None, datetime.time(9, 30)),)
+    early_close_1230 = datetime.time(12, 30)
+    early_close_130 = datetime.time(13, 30)
 
     @property
     def close_times(self):
@@ -270,7 +272,7 @@ class XSGOExchangeCalendar(ExchangeCalendar):
         ]
 
     def _starting_dates_and_close_times(self):
-        yield ((None, time(17)))
+        yield ((None, datetime.time(17)))
         for year in range(1980, 2050):
-            yield (pd.Timestamp("{}-03-01".format(year)), time(16))
-            yield (pd.Timestamp("{}-11-01".format(year)), time(17))
+            yield (pd.Timestamp("{}-03-01".format(year)), datetime.time(16))
+            yield (pd.Timestamp("{}-11-01".format(year)), datetime.time(17))

--- a/exchange_calendars/exchange_calendar_xtai.py
+++ b/exchange_calendars/exchange_calendar_xtai.py
@@ -120,7 +120,7 @@ def bridge_mon(dt: datetime.datetime) -> datetime.datetime | None:
     Notes
     -----
     If a holiday falls on a Tuesday an extra holiday is observed on Monday
-    to create a three day weekend.
+    to bridge the weekend and the official holiday.
     """
     dt -= ONE_DAY
     return dt if (dt.weekday() == MONDAY and dt.year > 2013) else None
@@ -135,7 +135,7 @@ def bridge_fri(dt: datetime.datetime) -> datetime.datetime | None:
     Notes
     -----
     If a holiday falls on a Thursday an extra holiday is observed on Friday
-    to create a three day weekend.
+    to bridge the weekend and the official holiday.
     """
     dt += ONE_DAY
     return dt if (dt.weekday() == FRIDAY and dt.year > 2013) else None

--- a/exchange_calendars/exchange_calendar_xwar.py
+++ b/exchange_calendars/exchange_calendar_xwar.py
@@ -13,7 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from datetime import time
+from __future__ import annotations
+
+import datetime
 
 import pandas as pd
 from pandas.tseries.holiday import EasterMonday, GoodFriday, Holiday
@@ -33,12 +35,12 @@ from .common_holidays import (
 from .exchange_calendar import HolidayCalendar, ExchangeCalendar
 
 
-def not_2004(datetime_index):
+def not_2004(dt: datetime.datetime) -> datetime.datetime | None:
     """
     Christmas Eve is a holiday every year except for whatever reason it was a
     trading day in 2004.
     """
-    return datetime_index[datetime_index.year != 2004]
+    return dt if dt.year != 2004 else None
 
 
 NewYearsDay = new_years_day()
@@ -110,8 +112,8 @@ class XWARExchangeCalendar(ExchangeCalendar):
 
     tz = timezone("Europe/Warsaw")
 
-    open_times = ((None, time(9)),)
-    close_times = ((None, time(17)),)
+    open_times = ((None, datetime.time(9)),)
+    close_times = ((None, datetime.time(17)),)
 
     @property
     def regular_holidays(self):

--- a/exchange_calendars/xbkk_holidays.py
+++ b/exchange_calendars/xbkk_holidays.py
@@ -1,4 +1,6 @@
-from datetime import timedelta
+from __future__ import annotations
+
+import datetime
 
 import pandas as pd
 from pandas.tseries.holiday import (
@@ -12,27 +14,23 @@ from .common_holidays import european_labour_day, new_years_day, new_years_eve
 from .exchange_calendar import MONDAY, SUNDAY
 
 
-def new_years_eve_observance(holidays):
+def new_years_eve_observance(dt: datetime.datetime) -> datetime.datetime | None:
     # New Year's Eve is a holiday every year except for 2003 for some reason.
-    holidays = holidays[holidays.year != 2003]
-
-    return pd.to_datetime([weekend_to_monday(day) for day in holidays])
+    return weekend_to_monday(dt) if dt.year != 2003 else None
 
 
-def new_years_day_observance(holidays):
+def new_years_day_observance(dt: datetime.datetime) -> datetime.datetime | None:
     # There was no extra observance of New Year's Day in 2006.
-    holidays = holidays[holidays.year != 2006]
-
-    return pd.to_datetime([next_monday_or_tuesday(day) for day in holidays])
+    return next_monday_or_tuesday(dt) if dt.year != 2006 else None
 
 
-def songkran_festival_last_day_observance(dt):
+def songkran_festival_last_day_observance(dt: datetime.datetime) -> datetime.datetime:
     """
     This function is similar to the pandas function `next_monday_or_tuesday`
     except it does not observe Saturday holidays on Monday.
     """
     if dt.weekday() == SUNDAY or dt.weekday() == MONDAY:
-        return dt + timedelta(days=1)
+        return dt + datetime.timedelta(days=1)
     return dt
 
 

--- a/tests/test_calendar_helpers.py
+++ b/tests/test_calendar_helpers.py
@@ -13,7 +13,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import pytz
-from hypothesis import assume, given, settings
+from hypothesis import assume, given, settings, HealthCheck
 from hypothesis import strategies as st
 from pandas.testing import assert_index_equal
 
@@ -640,7 +640,7 @@ class TestTradingIndex:
         if curtail and not (force_close and force_break_close):
             indices = lower_bounds.argsort()
             lower_bounds = lower_bounds.sort_values()
-            upper_bounds = upper_bounds[indices]
+            upper_bounds = upper_bounds.iloc[indices]
             curtail_mask = upper_bounds > lower_bounds.shift(-1)
             if curtail_mask.any():
                 upper_bounds[curtail_mask] = lower_bounds.shift(-1)[curtail_mask]
@@ -656,7 +656,7 @@ class TestTradingIndex:
         align=st_align(),
         align_pm=st_align(),
     )
-    @settings(deadline=None)
+    @settings(deadline=None, suppress_health_check=[HealthCheck.differing_executors])
     def test_indices_fuzz(
         self,
         data,
@@ -779,7 +779,7 @@ class TestTradingIndex:
         align=st_align(),
         align_pm=st_align(),
     )
-    @settings(deadline=None)
+    @settings(deadline=None, suppress_health_check=[HealthCheck.differing_executors])
     def test_intervals_fuzz(
         self,
         data,
@@ -919,7 +919,7 @@ class TestTradingIndex:
         force_break_close=st.booleans(),
         curtail_overlaps=st.booleans(),
     )
-    @settings(deadline=None)
+    @settings(deadline=None, suppress_health_check=[HealthCheck.differing_executors])
     def test_daily_fuzz(
         self,
         data,
@@ -953,7 +953,7 @@ class TestTradingIndex:
 
     @pytest.mark.parametrize("name", ["XHKG", "24/7", "CMES"])
     @given(data=st.data(), closed=st.sampled_from(["right", "both"]))
-    @settings(deadline=None)
+    @settings(deadline=None, suppress_health_check=[HealthCheck.differing_executors])
     def test_overlap_error_fuzz(self, data, name, calendars, answers, closed, one_min):
         """Fuzz for expected IndicesOverlapError.
 


### PR DESCRIPTION
Updates dependencies including pandas from 2.0.3 to 2.1.0.

The pandas update has introduced a bug and some warnings that have necessitated changes (more changes in fact that than the move from pandas 1.5 to 2.0!).

- Fixes #326 - updates functions passed to `Holiday` observance option. These functions now all take a `datetime.datetime`, never a `pandas.DatetimeIndex`.
  - This required notable changes to the XBUD and XTAI modules which both relied on previously being able to, effectively, observe a single holiday on multiple days (this provided for adding an extra holiday on a Friday/Monday when the official holiday fell on a Thursday/Tuesday and the extra day's holiday is stipulated to bridge the weekend and the official holiday). This is no longer an option, such that these 'bridge' days now require their own Holiday calendar.
- Fixes `FutureWarning` raised when indexing a `pandas.Series` directly with an `int` rather than via `Series.iloc`.
- Suppresses new hypothesis HealthCheck concerned with multiple executors.