### PR TITLE
Rename Asia/Calcutta to Asia/Kolkata

### DIFF
--- a/exchange_calendars/exchange_calendar_xbom.py
+++ b/exchange_calendars/exchange_calendar_xbom.py
@@ -426,8 +426,8 @@ class XBOMExchangeCalendar(PrecomputedExchangeCalendar):
     """
     Exchange calendar for the Bombay Stock Exchange (BSE, XBOM).
 
-    Open Time: 9:15 AM, Asia/Calcutta
-    Close Time: 3:30 PM, Asia/Calcutta
+    Open Time: 9:15 AM, Asia/Kolkata
+    Close Time: 3:30 PM, Asia/Kolkata
 
     Due to the complexity around the BSE holidays, we are hardcoding a list
     of holidays back to 1997, and forward through 2023.  There are no known
@@ -435,7 +435,7 @@ class XBOMExchangeCalendar(PrecomputedExchangeCalendar):
     """
 
     name = "XBOM"
-    tz = ZoneInfo("Asia/Calcutta")
+    tz = ZoneInfo("Asia/Kolkata")
     open_times = ((None, time(9, 15)),)
     close_times = ((None, time(15, 30)),)
 


### PR DESCRIPTION
In 2008, the timezone identifier Asia/Calcutta was renamed to
Asia/Kolkata due to the widespread adoption of the new city name over
the old one.

While the Asia/Calcutta alias still points to the Asia/Kolkata timezone,
it's worth noting that Debian unstable has relocated this alias to the
tzdata-legacy package, which is not included in the default
installation.

To ensure compatibility and consistency, it is recommended to use
Asia/Kolkata directly rather than relying on the Asia/Calcutta alias.

This change aligns with the current naming conventions.
