### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,10 +27,11 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.test_pypi_password }}
-        repository_url: https://test.pypi.org/legacy/
-        skip_existing: true
+        repository-url: https://test.pypi.org/legacy/
+        skip-existing: true
 
     - name: Install from testpypi and import
+      shell: bash
       run: |
         i=0
         while [ $i -lt 12 ] && [ "${{ github.ref_name }}" != $(pip index versions -i https://test.pypi.org/simple --pre exchange_calendars | cut -d'(' -f2 | cut -d')' -f1 | sed 1q) ];\
@@ -51,6 +52,7 @@ jobs:
         password: ${{ secrets.pypi_password }}
 
     - name: Install and import
+      shell: bash
       run: |
         i=0
         while [ $i -lt 12 ] && [ "${{ github.ref_name }}" != $(pip index versions -i https://pypi.org/simple --pre exchange_calendars | cut -d'(' -f2 | cut -d')' -f1 | sed 1q) ];\

--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -5,26 +5,26 @@
 #    pip-compile --output-file=etc/requirements.txt pyproject.toml
 #
 korean-lunar-calendar==0.3.1
-    # via exchange-calendars (pyproject.toml)
-numpy==1.26.1
+    # via exchange_calendars (pyproject.toml)
+numpy==1.26.2
     # via
-    #   exchange-calendars (pyproject.toml)
+    #   exchange_calendars (pyproject.toml)
     #   pandas
-pandas==2.1.1
-    # via exchange-calendars (pyproject.toml)
+pandas==2.1.4
+    # via exchange_calendars (pyproject.toml)
 pyluach==2.2.0
-    # via exchange-calendars (pyproject.toml)
+    # via exchange_calendars (pyproject.toml)
 python-dateutil==2.8.2
     # via
-    #   exchange-calendars (pyproject.toml)
+    #   exchange_calendars (pyproject.toml)
     #   pandas
 pytz==2023.3.post1
     # via pandas
 six==1.16.0
     # via python-dateutil
 toolz==0.12.0
-    # via exchange-calendars (pyproject.toml)
-tzdata==2023.3
+    # via exchange_calendars (pyproject.toml)
+tzdata==2023.4
     # via
-    #   exchange-calendars (pyproject.toml)
+    #   exchange_calendars (pyproject.toml)
     #   pandas

--- a/etc/requirements_dev.txt
+++ b/etc/requirements_dev.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --extra=dev --output-file=etc/requirements_dev.txt pyproject.toml
 #
-attrs==23.1.0
+attrs==23.2.0
     # via hypothesis
 build==1.0.3
     # via pip-tools
@@ -15,36 +15,36 @@ colorama==0.4.6
     #   build
     #   click
     #   pytest
-exceptiongroup==1.1.3
+exceptiongroup==1.2.0
     # via
     #   hypothesis
     #   pytest
 execnet==2.0.2
     # via pytest-xdist
 flake8==6.1.0
-    # via exchange-calendars (pyproject.toml)
-hypothesis==6.87.4
-    # via exchange-calendars (pyproject.toml)
-importlib-metadata==6.8.0
+    # via exchange_calendars (pyproject.toml)
+hypothesis==6.92.2
+    # via exchange_calendars (pyproject.toml)
+importlib-metadata==7.0.1
     # via build
 iniconfig==2.0.0
     # via pytest
 korean-lunar-calendar==0.3.1
-    # via exchange-calendars (pyproject.toml)
+    # via exchange_calendars (pyproject.toml)
 mccabe==0.7.0
     # via flake8
-numpy==1.26.1
+numpy==1.26.2
     # via
-    #   exchange-calendars (pyproject.toml)
+    #   exchange_calendars (pyproject.toml)
     #   pandas
 packaging==23.2
     # via
     #   build
     #   pytest
-pandas==2.1.1
-    # via exchange-calendars (pyproject.toml)
+pandas==2.1.4
+    # via exchange_calendars (pyproject.toml)
 pip-tools==7.3.0
-    # via exchange-calendars (pyproject.toml)
+    # via exchange_calendars (pyproject.toml)
 pluggy==1.3.0
     # via pytest
 py-cpuinfo==9.0.0
@@ -54,21 +54,21 @@ pycodestyle==2.11.1
 pyflakes==3.1.0
     # via flake8
 pyluach==2.2.0
-    # via exchange-calendars (pyproject.toml)
+    # via exchange_calendars (pyproject.toml)
 pyproject-hooks==1.0.0
     # via build
-pytest==7.4.2
+pytest==7.4.4
     # via
-    #   exchange-calendars (pyproject.toml)
+    #   exchange_calendars (pyproject.toml)
     #   pytest-benchmark
     #   pytest-xdist
 pytest-benchmark==4.0.0
-    # via exchange-calendars (pyproject.toml)
-pytest-xdist==3.3.1
-    # via exchange-calendars (pyproject.toml)
+    # via exchange_calendars (pyproject.toml)
+pytest-xdist==3.5.0
+    # via exchange_calendars (pyproject.toml)
 python-dateutil==2.8.2
     # via
-    #   exchange-calendars (pyproject.toml)
+    #   exchange_calendars (pyproject.toml)
     #   pandas
 pytz==2023.3.post1
     # via pandas
@@ -83,12 +83,12 @@ tomli==2.0.1
     #   pyproject-hooks
     #   pytest
 toolz==0.12.0
-    # via exchange-calendars (pyproject.toml)
-tzdata==2023.3
+    # via exchange_calendars (pyproject.toml)
+tzdata==2023.4
     # via
-    #   exchange-calendars (pyproject.toml)
+    #   exchange_calendars (pyproject.toml)
     #   pandas
-wheel==0.41.2
+wheel==0.42.0
     # via pip-tools
 zipp==3.17.0
     # via importlib-metadata

--- a/etc/requirements_minpandas.txt
+++ b/etc/requirements_minpandas.txt
@@ -8,7 +8,7 @@
 #
 #    pip-compile --upgrade --upgrade-package pandas==1.5 --extra=dev --output-file=etc/requirements_minpandas.txt pyproject.toml
 #
-attrs==23.1.0
+attrs==23.2.0
     # via hypothesis
 build==1.0.3
     # via pip-tools
@@ -19,36 +19,36 @@ colorama==0.4.6
     #   build
     #   click
     #   pytest
-exceptiongroup==1.1.3
+exceptiongroup==1.2.0
     # via
     #   hypothesis
     #   pytest
 execnet==2.0.2
     # via pytest-xdist
 flake8==6.1.0
-    # via exchange-calendars (pyproject.toml)
-hypothesis==6.87.4
-    # via exchange-calendars (pyproject.toml)
-importlib-metadata==6.8.0
+    # via exchange_calendars (pyproject.toml)
+hypothesis==6.92.2
+    # via exchange_calendars (pyproject.toml)
+importlib-metadata==7.0.1
     # via build
 iniconfig==2.0.0
     # via pytest
 korean-lunar-calendar==0.3.1
-    # via exchange-calendars (pyproject.toml)
+    # via exchange_calendars (pyproject.toml)
 mccabe==0.7.0
     # via flake8
-numpy==1.26.1
+numpy==1.26.2
     # via
-    #   exchange-calendars (pyproject.toml)
+    #   exchange_calendars (pyproject.toml)
     #   pandas
 packaging==23.2
     # via
     #   build
     #   pytest
 pandas==1.5.0
-    # via exchange-calendars (pyproject.toml)
+    # via exchange_calendars (pyproject.toml)
 pip-tools==7.3.0
-    # via exchange-calendars (pyproject.toml)
+    # via exchange_calendars (pyproject.toml)
 pluggy==1.3.0
     # via pytest
 py-cpuinfo==9.0.0
@@ -58,21 +58,21 @@ pycodestyle==2.11.1
 pyflakes==3.1.0
     # via flake8
 pyluach==2.2.0
-    # via exchange-calendars (pyproject.toml)
+    # via exchange_calendars (pyproject.toml)
 pyproject-hooks==1.0.0
     # via build
-pytest==7.4.2
+pytest==7.4.4
     # via
-    #   exchange-calendars (pyproject.toml)
+    #   exchange_calendars (pyproject.toml)
     #   pytest-benchmark
     #   pytest-xdist
 pytest-benchmark==4.0.0
-    # via exchange-calendars (pyproject.toml)
-pytest-xdist==3.3.1
-    # via exchange-calendars (pyproject.toml)
+    # via exchange_calendars (pyproject.toml)
+pytest-xdist==3.5.0
+    # via exchange_calendars (pyproject.toml)
 python-dateutil==2.8.2
     # via
-    #   exchange-calendars (pyproject.toml)
+    #   exchange_calendars (pyproject.toml)
     #   pandas
 pytz==2023.3.post1
     # via pandas
@@ -87,10 +87,10 @@ tomli==2.0.1
     #   pyproject-hooks
     #   pytest
 toolz==0.12.0
-    # via exchange-calendars (pyproject.toml)
-tzdata==2023.3
-    # via exchange-calendars (pyproject.toml)
-wheel==0.41.2
+    # via exchange_calendars (pyproject.toml)
+tzdata==2023.4
+    # via exchange_calendars (pyproject.toml)
+wheel==0.42.0
     # via pip-tools
 zipp==3.17.0
     # via importlib-metadata

--- a/tests/test_calendar_helpers.py
+++ b/tests/test_calendar_helpers.py
@@ -640,8 +640,12 @@ class TestTradingIndex:
             else:
                 day_upper = day_lower = pd.Series([], dtype="datetime64[ns, UTC]")
 
-            lower_bounds = pd.concat((am_lower, pm_lower, day_lower))
-            upper_bounds = pd.concat((am_upper, pm_upper, day_upper))
+            lower_bounds = pd.concat(
+                [srs for srs in (am_lower, pm_lower, day_lower) if not srs.empty]
+            )
+            upper_bounds = pd.concat(
+                [srs for srs in (am_upper, pm_upper, day_upper) if not srs.empty]
+            )
 
         else:
             lower_bounds, upper_bounds = bounds(opens, closes, force_close, align)

--- a/tests/test_exchange_calendar.py
+++ b/tests/test_exchange_calendar.py
@@ -2291,10 +2291,11 @@ class ExchangeCalendarTestBase:
             with pytest.raises(errors.NoSessionsError, match=re.escape(error_msg)):
                 calendar_cls(start=start, end=end)
 
-    def test_bound_min(self, calendar_cls, start_bound, today):
+    def test_bound_min(self, calendar_cls, start_bound, end_bound, today):
         assert calendar_cls.bound_min() == start_bound
         if start_bound is not None:
-            cal = calendar_cls(start_bound, today)
+            end = today if end_bound is None or today < end_bound else end_bound
+            cal = calendar_cls(start_bound, end)
             assert isinstance(cal, ExchangeCalendar)
 
             start = start_bound - pd.DateOffset(days=1)
@@ -2308,7 +2309,8 @@ class ExchangeCalendarTestBase:
     def test_bound_max(self, calendar_cls, end_bound, today):
         assert calendar_cls.bound_max() == end_bound
         if end_bound is not None:
-            cal = calendar_cls(today, end_bound)
+            start = today if today < end_bound else end_bound - pd.Timedelta(1, "D")
+            cal = calendar_cls(start, end_bound)
             assert isinstance(cal, ExchangeCalendar)
 
             end = end_bound + pd.DateOffset(days=1)


### PR DESCRIPTION
Updates dependencies.

Also
- Updates release workflow to use bash shell when checking release.
- Fixes tests:
  - Fixes `test_calendar_helpers.TestTradingIndex` for pandas FutureWarning.
  - Fixes `test_bound_min` and `test_bound_max` to accommodate end_bound
being earlier than today.