### PR TITLE
TST: Fix missing assertion in XSGO calendar tests

### DIFF
--- a/tests/test_xsgo_calendar.py
+++ b/tests/test_xsgo_calendar.py
@@ -186,4 +186,4 @@ class TestXSGOCalendar(ExchangeCalendarTestBase):
         )
         cal = default_calendar
         for date, close in dates_closes:
-            cal.closes[date] == pd.Timestamp(close, tz=cal.tz)
+            assert cal.closes[date] == pd.Timestamp(close, tz=cal.tz)


### PR DESCRIPTION
There is a dangling equality check in the tests here that looks like it should be an assertion.