### PR TITLE
BUG: Fix end-date-only TZ logic in holiday.py

### DIFF
--- a/exchange_calendars/pandas_extensions/holiday.py
+++ b/exchange_calendars/pandas_extensions/holiday.py
@@ -58,12 +58,12 @@ class Holiday(PandasHoliday):
             assert self.tz == self.start_date.tz
         if self.end_date is not None:
             if self.tz is None and self.end_date.tz is not None:
-                self.tz = start_date.tz
+                self.tz = end_date.tz
             if self.end_date.tz is None and self.tz is not None:
                 self.end_date = self.end_date.tz_localize(self.tz)
             assert self.tz == self.end_date.tz
         if self.start_date is not None and self.end_date is not None:
-            self.start_date.tz == self.end_date.tz
+            assert self.start_date.tz == self.end_date.tz
 
     def __repr__(self) -> str:
         info = ""


### PR DESCRIPTION
I don't think anything is actually using this, so hasn't tripped over it yet, but there is what looks like a "copy/pasta" bug in `holidays.py` that this fixes around handling of the range when the TZ is only specified on the end date. There is a missing assertion for matching start and end date timezones, too (there is currently what ruff calls a "pointless equality check" whose result is not checked).