### PR TITLE
feat: added new national holiday to BVMF calendar

### DIFF
--- a/exchange_calendars/exchange_calendar_bvmf.py
+++ b/exchange_calendars/exchange_calendar_bvmf.py
@@ -119,6 +119,13 @@ ConscienciaNegra = Holiday(
     start_date="2004-01-01",
     end_date="2022-01-01",
 )
+# Day of Black Awareness is now a national holiday, starting 2024
+ConscienciaNegraNacional = Holiday(
+    "Dia Nacional de Zumbi e da Consciencia Negra",
+    month=11,
+    day=20,
+    start_date="2024-01-01"
+)
 # Christmas Eve
 VesperaNatal = Holiday(
     "Vespera Natal",
@@ -209,6 +216,7 @@ class BVMFExchangeCalendar(ExchangeCalendar):
                 Finados,
                 ProclamacaoRepublica,
                 ConscienciaNegra,
+                ConscienciaNegraNacional,
                 VesperaNatal,
                 Natal,
                 AnoNovo,


### PR DESCRIPTION
On December 22nd, 2023, a new law was passed in Brazil, where Black Awareness Day became a national holiday, starting in 2024. Brazilian exchange "B3" (formerly known as BVMF), has already implemented the new calendar.