### PR TITLE
XDUB: Add May bank holiday post-2021

### DIFF
--- a/exchange_calendars/exchange_calendar_xdub.py
+++ b/exchange_calendars/exchange_calendar_xdub.py
@@ -59,13 +59,22 @@ LabourDayFrom2019 = european_labour_day(
     observance=weekend_to_monday,
 )
 
-MayBankHoliday = Holiday(
+MayBankHolidayTo2018 = Holiday(
     "May Bank Holiday",
     month=5,
     day=1,
     end_date="2019",
     offset=DateOffset(weekday=MO(1)),
 )
+
+MayBankHolidayFrom2021 = Holiday(
+    "May Bank Holiday",
+    month=5,
+    day=1,
+    start_date="2021",
+    offset=DateOffset(weekday=MO(1)),
+)
+
 JuneBankHoliday = Holiday(
     "June Bank Holiday",
     month=6,
@@ -143,7 +152,8 @@ class XDUBExchangeCalendar(ExchangeCalendar):
                 EasterMonday,
                 LabourDayTo2009,
                 LabourDayFrom2019,
-                MayBankHoliday,
+                MayBankHolidayTo2018,
+                MayBankHolidayFrom2021,
                 JuneBankHoliday,
                 ChristmasEve,
                 Christmas,


### PR DESCRIPTION
Closes: #383 

Whilst it looks correct that there is no Early May Bank Holiday for Euronext Dublin in 2019 and 2020, it does seem to have been reacted from 2021 onwards. See screenshots below of excerpts from the Euronext website:

Euronext 2019 - no May Bank (https://web.archive.org/web/20190708142940/https://www.euronext.com/en/trade/trading-hours-holidays): 

![image](https://github.com/gerrymanoim/exchange_calendars/assets/30357972/855e7a13-92c6-41e5-a421-f0aa9a496966)

Euronext 2020 - no May Bank (https://web.archive.org/web/20200904035212/https://www.euronext.com/en/trade/trading-hours-holidays):

![image](https://github.com/gerrymanoim/exchange_calendars/assets/30357972/f4d160f4-c539-44f1-b554-0b8f34849da2)

Euronext 2021 - May Bank (https://www.euronext.com/en/trade/trading-hours-holidays):

![image](https://github.com/gerrymanoim/exchange_calendars/assets/30357972/2d43095e-cd6b-43ff-a993-686fb4e33f4e)

and on that same page you can see calendars for 2021 onwards, all of which have the early May Bank Holiday.

------------------

**Workflow to add a new Exchange Calendar**

It's recommended that whilst working through the process reference be made to existing calendar and test classes.

- [x] Add calendar module `exchange_calendars/exchange_calendar_{Exchange MIC}.py`. Module should contain a subclass of the abstract base class `ExchangeCalendar` (in `exchange_calendars/exchange_calendar.py`).
  - [x] Name subclass `{Exchange MIC}ExchangeCalendar`.
  - [x] Override methods and properties as required, being guided by ExchangeCalendar documentation and in-code comments. All abstract properties must be overriden.
  - [x] Include references / links for holidays and timings (either to class documentation or as comments).
- [x] Import calendar class to `exchange_calendars/calendar_utils.py` and add class to `_default_calendar_factories`. 
- [x] Add calendar test module `tests/test_{Exchange MIC}_calendar.py` Module should contain a subclass of the test base class `ExchangeCalendarTestBase` (in `tests/test_exchange_calendars.py`).
  - [x] Name subclass `Test{Exchange MIC}Calendar`.
  - [x] Override fixtures as required, being guided by ExchangeCalendarTestBase documentation and in-code comments. The `calendar_cls` and `max_session_hours` fixtures must be overriden.
- [x] Add a .csv file containing expected timings to `tests/resources/{Exchange MIC}.csv`. This file be generated by executing `python etc/make_exchange_calendar_test_csv.py {Exchange MIC}`. See script's documentation.
- [x] Add new exchange to Calendars table of README.md.
- [x] PR it!

**Workflow to modify an existing Exchange Calendar**

- [x] Modify calendar class as required. 
- [x] Modify the test resources file (e.g `tests/resources/{Exchange MIC}.csv`), either manually or by executing `python etc/make_exchange_calendar_test_csv.py {Exchange MIC}`.
- [x] Check if any of the fixtures in `tests/test_{Exchange MIC}_calendar.py` need updating to reflect your changes.
- [x] Add references to any new/modified holidays in `exchange_calendars/exchange_calendar_{Exchange MIC}.py`.
