### PR TITLE
BUG Fix timezone names

### DIFF
--- a/exchange_calendars/exchange_calendar_xetr.py
+++ b/exchange_calendars/exchange_calendar_xetr.py
@@ -103,7 +103,7 @@ class XETRExchangeCalendar(ExchangeCalendar):
 
     name = "XETR"
 
-    tz = ZoneInfo("CET")
+    tz = ZoneInfo("Europe/Berlin")
 
     open_times = ((None, time(9)),)
 

--- a/exchange_calendars/exchange_calendar_xfra.py
+++ b/exchange_calendars/exchange_calendar_xfra.py
@@ -102,7 +102,7 @@ class XFRAExchangeCalendar(ExchangeCalendar):
 
     name = "XFRA"
 
-    tz = ZoneInfo("CET")
+    tz = ZoneInfo("Europe/Berlin")
 
     open_times = ((None, time(9)),)
 

--- a/exchange_calendars/exchange_calendar_xnze.py
+++ b/exchange_calendars/exchange_calendar_xnze.py
@@ -185,7 +185,7 @@ class XNZEExchangeCalendar(ExchangeCalendar):
 
     name = "XNZE"
 
-    tz = ZoneInfo("NZ")
+    tz = ZoneInfo("Pacific/Auckland")
 
     open_times = ((None, time(10)),)
 

--- a/tests/test_exchange_calendar.py
+++ b/tests/test_exchange_calendar.py
@@ -2124,7 +2124,7 @@ class ExchangeCalendarTestBase:
 
         Notes
         -----
-        NB Any test that employs this fixture assumes the accuarcy of the
+        NB Any test that employs this fixture assumes the accuracy of the
         default calendar's `tz` property.
         """
         cal = default_calendar


### PR DESCRIPTION
Hi all,

I noticed that some calendars use an incorrect or dubious timezone info. Specifically, XETR and XFRA use `ZoneInfo('CET')` and XNZE uses `ZoneInfo('NZ')`.

Re XETR and XFRA, I think it's incorrect to use CET since this is a standard time, i.e. a fixed offset (+01:00) to UTC. But since Germany observes summer time (CEST = +02:00), the correct timezone to use would be `ZoneInfo('Europe/Berlin')`.

For XNZE, I'm not even sure what the definition of `ZoneInfo('NZ') is, but `ZoneInfo('Pacific/Auckland')` seems to be the correct time zone to use.
