### PR TITLE
Ensure ad-hoc holidays are proper Pandas timestamps.

### DIFF
--- a/exchange_calendars/exchange_calendar_xbue.py
+++ b/exchange_calendars/exchange_calendar_xbue.py
@@ -344,15 +344,16 @@ class XBUEExchangeCalendar(ExchangeCalendar):
             "2016-11-28",  # Day of National Sovereignty
         ]
 
-        return list(
-            chain(
+        return [
+            pd.Timestamp(d)
+            for d in chain(
                 misc_adhocs,
                 market_closures_2002_jan,
                 market_closures_2002_apr,
                 bridge_days,
                 irregular_observances,
             )
-        )
+        ]
 
     @property
     def special_closes(self):

--- a/exchange_calendars/exchange_calendar_xphs.py
+++ b/exchange_calendars/exchange_calendar_xphs.py
@@ -410,12 +410,13 @@ class XPHSExchangeCalendar(ExchangeCalendar):
             "2010-12-31",
         ]
 
-        return list(
-            chain(
+        return [
+            pd.Timestamp(d)
+            for d in chain(
                 misc_adhoc,
                 pre_2011_holidays,
                 ChineseNewYearAfter2011,
                 philippines_eid_al_adha,
                 philippines_eid_al_fitr,
             )
-        )
+        ]


### PR DESCRIPTION
Some calendars define ad-hoc holidays not as Pandas timestamps, but as strings. This may cause breaks as the interface mandates a list of Pandas timestamps.