### PR TITLE
Bump supported python upper limit to 3.12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,11 +15,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.9", "3.11"]
+        python-version: ["3.9", "3.12"]
         include:
           - python-version: "3.9"
             requirements_file: requirements_dev.txt
-          - python-version: "3.11"
+          - python-version: "3.12"
             requirements_file: requirements_minpandas.txt
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: Apache Software License",
     "Intended Audience :: Science/Research",
     "Topic :: Scientific/Engineering",
@@ -63,4 +64,4 @@ write_to = "exchange_calendars/_version.py"
 
 [tool.black]
 line-length = 88
-target-version = ['py39', 'py310', 'py311']
+target-version = ['py39', 'py310', 'py311', 'py312']


### PR DESCRIPTION
Changes test matrix to use 3.12 as opposed to 3.11.