### PR TITLE
Update devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Python version: 3, 3.8, 3.7, 3.6
+# [Choice] Python version: 3, 3.10, 3.11, 3.12
 ARG VARIANT=3
 FROM mcr.microsoft.com/vscode/devcontainers/python:${VARIANT}
 
@@ -8,9 +8,9 @@ ARG NODE_VERSION="lts/*"
 RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "source /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 
 # [Optional] If your pip requirements rarely change, uncomment this section to add them to the image.
-COPY etc/requirements_locked.txt /tmp/pip-tmp/
+COPY etc/requirements_dev.txt /tmp/pip-tmp/
 RUN pip3 --disable-pip-version-check --no-cache-dir install ipython \
-   && pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements_locked.txt \
+   && pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements_dev.txt \
    && rm -rf /tmp/pip-tmp
 
 # [Optional] Uncomment this section to install additional OS packages.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,8 +4,8 @@
 		"dockerfile": "Dockerfile",
 		"context": "..",
 		"args": {
-			// Update 'VARIANT' to pick a Python version: 3, 3.6, 3.7, 3.8
-			"VARIANT": "3.9",
+			// Update 'VARIANT' to pick a Python version: 3, 3.10, 3.11, 3.12
+			"VARIANT": "3.10",
 			// Options
 			"INSTALL_NODE": "false",
 			"NODE_VERSION": "lts/*"


### PR DESCRIPTION
Devcontainer is not starting due to missing `etc/requirements_locked.txt` file.

Changes:
* Using `etc/requirements_dev.txt` instead of `etc/requirements_locked.txt` for devcontainer.
* Changed Python version from 9 to 10 (current min version) for devcontainer.

