### PR TITLE
japan tokyo exchange close 30 minutes later

### DIFF
--- a/exchange_calendars/exchange_calendar_xtks.py
+++ b/exchange_calendars/exchange_calendar_xtks.py
@@ -85,7 +85,7 @@ class XTKSExchangeCalendar(ExchangeCalendar):
     open_times = ((None, time(9)),)
     break_start_times = ((None, time(11, 30)),)
     break_end_times = ((None, time(12, 30)),)
-    close_times = ((None, time(15)),)
+    close_times = ((None, time(15, 30)),)
 
     @classmethod
     def bound_min(cls) -> pd.Timestamp:

--- a/exchange_calendars/exchange_calendar_xtks.py
+++ b/exchange_calendars/exchange_calendar_xtks.py
@@ -85,7 +85,7 @@ class XTKSExchangeCalendar(ExchangeCalendar):
     open_times = ((None, time(9)),)
     break_start_times = ((None, time(11, 30)),)
     break_end_times = ((None, time(12, 30)),)
-    close_times = ((None, time(15, 30)),)
+    close_times = ((None, time(15)), (pd.Timestamp("2024-11-05"), time(15, 30)))
 
     @classmethod
     def bound_min(cls) -> pd.Timestamp:


### PR DESCRIPTION
https://english.kyodonews.net/news/2024/11/e18d7d2218be-tokyo-stock-exchange-extends-trading-hours-for-1st-time-in-70-years.html#:~:text=With%20the%20first%20extension%20of,parent%20of%20the%20bourse%27s%20operator.