### PR TITLE
Avoid using legacy time zone name 'CET' in tests

### DIFF
--- a/exchange_calendars/exchange_calendar_xdus.py
+++ b/exchange_calendars/exchange_calendar_xdus.py
@@ -94,7 +94,7 @@ class XDUSExchangeCalendar(ExchangeCalendar):
 
     name = "XDUS"
 
-    tz = ZoneInfo("CET")
+    tz = ZoneInfo("Europe/Brussels")
 
     open_times = ((None, time(8)),)
 

--- a/exchange_calendars/exchange_calendar_xham.py
+++ b/exchange_calendars/exchange_calendar_xham.py
@@ -94,7 +94,7 @@ class XHAMExchangeCalendar(ExchangeCalendar):
 
     name = "XHAM"
 
-    tz = ZoneInfo("CET")
+    tz = ZoneInfo("Europe/Brussels")
 
     open_times = ((None, time(8)),)
 


### PR DESCRIPTION
This commit replaces the legacy time zone name CET with the current name Europe/Brussels in two tests.

Release 2024b of the tz database removed System V symlinks including the symlink that points from CET to Europe/Brussels.

In Debian the CET symlink has moved from the tzdata package to tzdata-legacy.

See https://data.iana.org/time-zones/tzdb-2024b/NEWS and https://lists.debian.org/debian-devel-changes/2024/10/msg00256.html