### PR TITLE
Add Jimmy Carter Day of Mourning

### DIFF
--- a/exchange_calendars/exchange_calendar_xnys.py
+++ b/exchange_calendars/exchange_calendar_xnys.py
@@ -146,6 +146,7 @@ class XNYSExchangeCalendar(ExchangeCalendar):
     - Closed at 1:00 PM on Friday, December 31, 1999
     - Closed at 1:00 PM on Friday, December 26, 1997
     - Closed at 1:00 PM on Friday, December 26, 2003
+    - Closed on 1/9/2025 due to Jimmy Carter's death.
 
     NOTE: The exchange was **not** closed early on Friday December 26, 2008,
     nor was it closed on Friday December 26, 2014. The next Thursday Christmas

--- a/exchange_calendars/us_holidays.py
+++ b/exchange_calendars/us_holidays.py
@@ -360,8 +360,8 @@ HurricaneGloriaClosing = [Timestamp("1985-09-27")]
 # - President Ronald W. Reagan - June 11, 2004
 # - President Gerald R. Ford - Jan 2, 2007
 # - President George H.W. Bush - Dec 5, 2018
+# - President Jimmy Carter - Jan 9, 2025
 # added Truman and Johnson to go back to 1970
-# - President Jimmy Carter - Jan 5, 2025
 # http://s3.amazonaws.com/armstrongeconomics-wp/2013/07/NYSE-Closings.pdf
 USNationalDaysofMourning = [
     Timestamp("1963-11-25"),

--- a/exchange_calendars/us_holidays.py
+++ b/exchange_calendars/us_holidays.py
@@ -361,6 +361,7 @@ HurricaneGloriaClosing = [Timestamp("1985-09-27")]
 # - President Gerald R. Ford - Jan 2, 2007
 # - President George H.W. Bush - Dec 5, 2018
 # added Truman and Johnson to go back to 1970
+# - President Jimmy Carter - Jan 5, 2025
 # http://s3.amazonaws.com/armstrongeconomics-wp/2013/07/NYSE-Closings.pdf
 USNationalDaysofMourning = [
     Timestamp("1963-11-25"),
@@ -372,4 +373,5 @@ USNationalDaysofMourning = [
     Timestamp("2004-06-11"),
     Timestamp("2007-01-02"),
     Timestamp("2018-12-05"),
+    Timestamp("2025-01-09"),
 ]

--- a/tests/test_xnys_calendar.py
+++ b/tests/test_xnys_calendar.py
@@ -61,6 +61,7 @@ class TestXNYSCalendar(ExchangeCalendarTestBase):
             "1994-04-27",  # Richard Nixon
             "1973-01-25",  # Lyndon B. Johnson
             "1972-12-28",  # Harry S. Truman
+            "2025-01-09",  # Jimmy Carter
             # National Days of Mourning
         ]
 


### PR DESCRIPTION
Added Jimmy Carter Day of Mourning for XNYS, XCBF, CMES, and IEPA

Sources:
Nasdaq - https://www.nasdaq.com/press-release/nasdaq-announces-closure-its-us-markets-honor-national-day-mourning-former-president

ICE - https://ir.theice.com/press/news-details/2024/The-New-York-Stock-Exchange-Will-Close-Markets-on-January-9-to-Honor-the-Passing-of-Former-President-Jimmy-Carter-on-National-Day-of-Mourning/default.aspx

CME - https://www.cmegroup.com/media-room/press-releases/2025/12/30/cme_group_announcestradinghoursforusnationaldayofmourningtohonor.html