### PR TITLE
Bump max Python version to 3.13

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.13"
     - name: Install dependencies
       run: |
         pip install -e .[dev] -c etc/requirements_dev.txt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,9 +19,9 @@ jobs:
         python-version: ["3.10", "3.13"]
         include:
           - python-version: "3.10"
-            requirements_file: requirements_dev.txt
-          - python-version: "3.13"
             requirements_file: requirements_minpandas.txt
+          - python-version: "3.13"
+            requirements_file: requirements_dev.txt
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,11 +16,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.10", "3.12"]
+        python-version: ["3.10", "3.13"]
         include:
           - python-version: "3.10"
             requirements_file: requirements_dev.txt
-          - python-version: "3.12"
+          - python-version: "3.13"
             requirements_file: requirements_minpandas.txt
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.12
+    - name: Set up Python 3.13
       uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.13"
 
     - name: Install build dependencies
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,11 +6,11 @@ repos:
     - id: end-of-file-fixer
     - id: trailing-whitespace
 - repo: https://github.com/pycqa/flake8
-  rev: 6.1.0
+  rev: 7.1.1
   hooks:
     - id: flake8
 - repo: https://github.com/psf/black
-  rev: 23.7.0
+  rev: 24.10.0
   hooks:
     - id: black
       language_version: python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 dependencies = [
     "numpy",
-    "pandas>=1.5",
+    "pandas",
     "pyluach",
     "toolz",
     "tzdata",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: Apache Software License",
     "Intended Audience :: Science/Research",
     "Topic :: Scientific/Engineering",
@@ -63,4 +64,4 @@ write_to = "exchange_calendars/_version.py"
 
 [tool.black]
 line-length = 88
-target-version = ['py310', 'py311', 'py312']
+target-version = ['py310', 'py311', 'py312', 'py313']


### PR DESCRIPTION
Bumps max Python version to 3.13.

Updates:
- workflows to use 3.13 (including upper version of test matrix).
- pyproject.toml project classifiers (as declared to PyPI).