### PR TITLE
Use Python tzdata in tests

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,6 +13,9 @@ RUN pip3 --disable-pip-version-check --no-cache-dir install ipython \
    && pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements_dev.txt \
    && rm -rf /tmp/pip-tmp
 
+# Set the PYTHONTZPATH environment variable to use Python's tzdata package instead of the operating system's timezone data.
+RUN python -c 'import os; print("export PYTHONTZPATH=\"" + os.path.dirname(os.__file__) + "\"")' >> /home/vscode/.profile
+
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 #     && apt-get -y install --no-install-recommends <your-package-list-here>

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,16 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r etc/${{matrix.requirements_file}}
         pip install -e .
+    - if: runner.os != 'Windows'
+      name: Set up Python tzdata on Linux and macOS
+      run: |
+        PYTHONTZPATH=$(python -c "import os; print(os.path.dirname(os.__file__))")
+        echo "PYTHONTZPATH=$PYTHONTZPATH" >> $GITHUB_ENV
+    - if: runner.os == 'Windows'
+      name: Set up Python tzdata on Windows
+      run: |
+        $PYTHONTZPATH = python -c "import os; print(os.path.dirname(os.__file__))"
+        echo "PYTHONTZPATH=$PYTHONTZPATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
     - name: Lint with flake8
       run: |
         flake8

--- a/etc/make_exchange_calendar_test_csv.py
+++ b/etc/make_exchange_calendar_test_csv.py
@@ -23,8 +23,10 @@ where:
             "default" to use calendar's default end date.
 """
 
+import os
 import sys
 import pathlib
+import tzdata
 
 import pandas as pd
 
@@ -71,6 +73,16 @@ df = pd.DataFrame(
     columns=["open", "close", "break_start", "break_end"],
     index=cal.closes.index,
 )
+
+# Set the PYTHONTZPATH environment variable to use Python's tzdata package instead of the operating system's timezone data.
+# This ensures consistent timezone data across all platforms when running tests.
+python_tzdata_path = os.getenv('PYTHONTZPATH')
+print(f"Is environment variable PYTHONTZPATH set? {'Yes' if os.getenv('PYTHONTZPATH') else 'No'}")
+if not python_tzdata_path:
+    python_tzdata_path = os.path.dirname(os.__file__)
+    print(f"Setting PYTHONTZPATH to {python_tzdata_path}")
+    os.putenv('PYTHONTZPATH', python_tzdata_path)
+print(f"Using tzdata version: {tzdata.IANA_VERSION}")
 
 print(f"Writing test CSV file to {path}")
 df.to_csv(path, date_format="%Y-%m-%dT%H:%M:%SZ")


### PR DESCRIPTION
Use Python tzdata for consistent timezone data across platforms when running tests.

This PR includes the following changes (which only affect testing):

* Configure GitHub runners to use Python tzdata.
* Use Python tzdata in `etc/make_exchange_calendar_test_csv.py`.
* Use Python tzdata in the devcontainer.

Python tzdata is used as a fallback for systems that do not have system timezone data installed. By setting the PYTHONTZPATH environment variable, Python's tzdata package is used instead of the operating system's timezone data. This will prevent tests from failing due to changes that are beyond the control of this project, such as modifications to timezone data on a GitHub runner or differences on users' local machines.

Tests for the Philippine Stock Exchange (XPHS) are failing due to changes in timezone data on the GitHub runner (macos-latest) with Python 3.10, but tests are passing on other platforms (Ubuntu and Windows). See issue #452 and PR #460.