### PR TITLE
Date type alias takes datetime.date

### DIFF
--- a/exchange_calendars/calendar_helpers.py
+++ b/exchange_calendars/calendar_helpers.py
@@ -21,7 +21,7 @@ NP_NAT = pd.NaT.value
 
 # Use Date type where input does not need to represent an actual session
 # and will be parsed by parse_date.
-Date = pd.Timestamp | str | int | float | datetime.datetime
+Date = pd.Timestamp | str | int | float | datetime.datetime | datetime.date
 
 # Use Session type where input should represent an actual session and will
 # be parsed by parse_session.

--- a/tests/test_calendar_helpers.py
+++ b/tests/test_calendar_helpers.py
@@ -123,7 +123,14 @@ def date(calendar) -> abc.Iterator[str]:
     yield date_
 
 
-@pytest.fixture(params=["2021-06-05", pd.Timestamp("2021-06-05")])
+@pytest.fixture(
+    params=[
+        "2021-06-05",
+        pd.Timestamp("2021-06-05"),
+        datetime.datetime(2021, 6, 5),
+        datetime.date(2021, 6, 5),
+    ]
+)
 def date_mult(request, calendar) -> abc.Iterator[str | pd.Timestamp]:
     """Date that does not represent a session of `calendar`."""
     date = request.param


### PR DESCRIPTION
We are using exchange calendars but keep getting lint errors when we try to call methods like `ExchangeCalendar.sessions_in_range` with `datetime.date`s, which is a bit counter-intuitive. 
From my understanding the `Date` type alias is passed to `pd.Timestamp` for parsing, which is happy with `datetime.date`s. Could we please add it, in addition to `datetime.datetime`?