### PR TITLE
Add 2024-11-20 election holiday for XBOM

### DIFF
--- a/exchange_calendars/exchange_calendar_xbom.py
+++ b/exchange_calendars/exchange_calendar_xbom.py
@@ -437,6 +437,7 @@ precomputed_bse_holidays = pd.to_datetime(
         "2024-10-02",
         "2024-11-01",
         "2024-11-15",
+        "2024-11-20", # Maharashtra Assembly Elections
         "2024-12-25",
         "2025-02-26",
         "2025-03-14",


### PR DESCRIPTION
See:
https://economictimes.indiatimes.com/markets/stocks/news/is-bse-nse-keeping-stock-market-closed-for-maharashtra-elections-today/articleshow/115449307.cms?from=mdr

https://www.hindustantimes.com/business/stock-market-holiday-on-maharashtra-election-is-the-bse-and-nse-open-or-closed-on-november-20-101731996763094.html
