### PR TITLE
Use np.intp for 32-bit compatibility (#410)

### DIFF
--- a/exchange_calendars/calendar_helpers.py
+++ b/exchange_calendars/calendar_helpers.py
@@ -575,7 +575,7 @@ class _TradingIndex:
 
         # evaluate number of indices for each session
         num_intervals = (end_nanos - start_nanos) / self.interval_nanos
-        num_indices = np.ceil(num_intervals).astype("int64")
+        num_indices = np.ceil(num_intervals).astype(np.intp)
 
         if force_close:
             if self.closed_right:


### PR DESCRIPTION
Fixes a test failure on 32-bit platforms (e.g. i386) due to NumPy refusing to safely cast between int64 and int32 in the .repeat() call.

Casting the number of intervals to np.intp ensures compatibility with the platform's expected integer size for indexing operations, preventing the TypeError observed on i386.