### PR TITLE
Refactor Orthodox Easter related holidays

### DIFF
--- a/exchange_calendars/common_holidays.py
+++ b/exchange_calendars/common_holidays.py
@@ -1,5 +1,4 @@
 import pandas as pd
-from dateutil.easter import EASTER_ORTHODOX, easter
 from pandas.tseries.holiday import FR, DateOffset, Easter, Holiday
 from pandas.tseries.offsets import Day
 
@@ -144,6 +143,17 @@ def corpus_christi(start_date=None, end_date=None):
     )
 
 
+def orthodox_ash_monday(start_date=None, end_date=None):
+    return Holiday(
+        "Ash Monday",
+        month=1,
+        day=1,
+        offset=[OrthodoxEaster(), -Day(48)],
+        start_date=start_date,
+        end_date=end_date,
+    )
+
+
 def orthodox_good_friday(start_date=None, end_date=None):
     return Holiday(
         "Good Friday",
@@ -172,6 +182,28 @@ def orthodox_easter_tuesday(start_date=None, end_date=None):
         month=1,
         day=1,
         offset=[OrthodoxEaster(), Day(2)],
+        start_date=start_date,
+        end_date=end_date,
+    )
+
+
+def orthodox_pentecost(start_date=None, end_date=None):
+    return Holiday(
+        "Pentecost",
+        month=1,
+        day=1,
+        offset=[OrthodoxEaster(), Day(49)],
+        start_date=start_date,
+        end_date=end_date,
+    )
+
+
+def orthodox_whit_monday(start_date=None, end_date=None):
+    return Holiday(
+        "Whit Monday",
+        month=1,
+        day=1,
+        offset=[OrthodoxEaster(), Day(50)],
         start_date=start_date,
         end_date=end_date,
     )
@@ -467,15 +499,3 @@ eid_al_adha_first_day = pd.to_datetime(
         "2049-09-08",
     ]
 )
-
-
-def orthodox_easter(start_date="1980", end_date="2030"):
-    """
-    This function gives a DatetimeIndex of Orthodox Easter dates from start_date to end_date
-    """
-    return pd.to_datetime(
-        [
-            easter(year, method=EASTER_ORTHODOX)
-            for year in range(int(start_date), int(end_date) + 1)
-        ]
-    )

--- a/exchange_calendars/exchange_calendar_asex.py
+++ b/exchange_calendars/exchange_calendar_asex.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from datetime import time, timedelta
+from datetime import time
 from itertools import chain
 from zoneinfo import ZoneInfo
 
@@ -27,7 +27,10 @@ from .common_holidays import (
     epiphany,
     european_labour_day,
     new_years_day,
-    orthodox_easter,
+    orthodox_ash_monday,
+    orthodox_good_friday,
+    orthodox_easter_monday,
+    orthodox_whit_monday,
 )
 from .exchange_calendar import HolidayCalendar, ExchangeCalendar
 
@@ -36,7 +39,7 @@ NewYearsDay = new_years_day()
 
 Epiphany = epiphany()
 
-OrthodoxAshMonday = orthodox_easter() - timedelta(48)
+OrthodoxAshMonday = orthodox_ash_monday()
 
 NationalHoliday1 = Holiday(
     "Independence Day",
@@ -44,13 +47,13 @@ NationalHoliday1 = Holiday(
     day=25,
 )
 
-OrthodoxGoodFriday = orthodox_easter() - timedelta(2)
+OrthodoxGoodFriday = orthodox_good_friday()
 
-OrthodoxEasterMonday = orthodox_easter() + timedelta(1)
+OrthodoxEasterMonday = orthodox_easter_monday()
 
 LabourDay = european_labour_day()
 
-OrthodoxWhitMonday = orthodox_easter() + timedelta(50)
+OrthodoxWhitMonday = orthodox_whit_monday()
 
 AssumptionDay = assumption_day()
 
@@ -114,10 +117,14 @@ class ASEXExchangeCalendar(ExchangeCalendar):
             [
                 NewYearsDay,
                 Epiphany,
+                OrthodoxEasterMonday,
                 NationalHoliday1,
                 GoodFriday,
                 EasterMonday,
+                OrthodoxGoodFriday,
+                OrthodoxAshMonday,
                 LabourDay,
+                OrthodoxWhitMonday,
                 AssumptionDay,
                 NationalHoliday2,
                 ChristmasEve,
@@ -152,10 +159,5 @@ class ASEXExchangeCalendar(ExchangeCalendar):
             chain(
                 debt_crisis_holidays,
                 misc_adhoc_holidays,
-                # TODO: Investigate making orthodox easter adhocs actual holidays
-                OrthodoxGoodFriday,
-                OrthodoxEasterMonday,
-                OrthodoxWhitMonday,
-                OrthodoxAshMonday,
             )
         )

--- a/exchange_calendars/exchange_calendar_xbse.py
+++ b/exchange_calendars/exchange_calendar_xbse.py
@@ -1,16 +1,19 @@
-from datetime import time, timedelta
-from itertools import chain
+from datetime import time
 from zoneinfo import ZoneInfo
 
 from pandas.tseries.holiday import Holiday
+from pandas.tseries.offsets import Day
 
 from .common_holidays import (
     christmas,
+    orthodox_good_friday,
+    orthodox_easter_monday,
     european_labour_day,
+    orthodox_pentecost,
     new_years_day,
-    orthodox_easter,
 )
 from .exchange_calendar import HolidayCalendar, ExchangeCalendar
+from .pandas_extensions.offsets import OrthodoxEaster
 
 NewYearsDay = new_years_day()
 
@@ -20,9 +23,9 @@ RomanianPrincipalitiesUnificationDay = Holiday(
     "Romanian Principalities Unification Day", month=1, day=24
 )
 
-OrthodoxGoodFriday = orthodox_easter() - timedelta(2)
+OrthodoxGoodFriday = orthodox_good_friday()
 
-OrthodoxEasterMonday = orthodox_easter() + timedelta(1)
+OrthodoxEasterMonday = orthodox_easter_monday()
 
 LabourDay = european_labour_day()
 
@@ -33,9 +36,14 @@ ChildrensDay = Holiday(
     day=1,
 )
 
-OrthodoxPentecost = orthodox_easter() + timedelta(49)
+OrthodoxPentecost = orthodox_pentecost()
 
-DescentOfTheHolySpirit = orthodox_easter() + timedelta(50)
+DescentOfTheHolySpirit = Holiday(
+    "Descent of the Holy Spirit",
+    month=1,
+    day=1,
+    offset=[OrthodoxEaster(), Day(50)],
+)
 
 StMarysDay = Holiday(
     "St. Mary's day",
@@ -66,7 +74,7 @@ SecondDayOfChristmas = Holiday(
 
 class XBSEExchangeCalendar(ExchangeCalendar):
     """
-    Exchange calendar for the BUCHAREST Stock Exchange (XBSE).
+    Exchange calendar for the Bucharest Stock Exchange (XBSE).
 
     Open Time: 10:00 AM, EET
     Close Time: 5:45 PM, EET
@@ -76,9 +84,10 @@ class XBSEExchangeCalendar(ExchangeCalendar):
       - Day after New Year's Day
       - Romanian Principalities Unification Day
       - Orthodox Good Friday
-      - Orthodox Easter
+      - Orthodox Easter Monday
       - Labour Day
       - Orthodox Pentecost
+      - Descent of the Holy Spirit
       - Children's Day
       - Assumption of Virgin Mary
       - St Andrew's day
@@ -104,7 +113,11 @@ class XBSEExchangeCalendar(ExchangeCalendar):
                 NewYearsDay,
                 DayAfterNewYearsDay,
                 RomanianPrincipalitiesUnificationDay,
+                OrthodoxGoodFriday,
+                OrthodoxEasterMonday,
                 LabourDay,
+                OrthodoxPentecost,
+                DescentOfTheHolySpirit,
                 ChildrensDay,
                 StMarysDay,
                 StAndrewsDay,
@@ -112,15 +125,4 @@ class XBSEExchangeCalendar(ExchangeCalendar):
                 ChristmasDay,
                 SecondDayOfChristmas,
             ]
-        )
-
-    @property
-    def adhoc_holidays(self):
-        return list(
-            chain(
-                OrthodoxGoodFriday,
-                OrthodoxEasterMonday,
-                OrthodoxPentecost,
-                DescentOfTheHolySpirit,
-            )
         )


### PR DESCRIPTION
This PR closes issue #73

Refactor the Orthodox Easter-related holidays for the Athens Stock Exchange and the Bucharest Stock Exchange by defining them as regular holidays instead of ad hoc holidays.