### PR TITLE
Set trusted-publishing `uv` option via `pyproject.toml`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,22 +22,22 @@ jobs:
     - name: Build
       run: uv build
 
-    - name: Publish distribution 📦 to Test PyPI
-      run: uv publish --index testpypi
-    - name: Check test install and import
-      run: |
-        sleep 5  # Wait for Test Pypi to publish
-        # Include pypi index for deps not available from test pypi...
-        uv run \
-          --with exchange-calendars \
-          --refresh-package exchange-calendars \
-          --index https://test.pypi.org/simple \
-          --index https://pypi.org/simple \
-          --index-strategy unsafe-best-match \
-          --no-project \
-          --isolated \
-          -- \
-          python -c 'import exchange_calendars; print(f"{exchange_calendars.__version__=}")'
+    # - name: Publish distribution 📦 to Test PyPI
+    #   run: uv publish --index testpypi
+    # - name: Check test install and import
+    #   run: |
+    #     sleep 5  # Wait for Test Pypi to publish
+    #     # Include pypi index for deps not available from test pypi...
+    #     uv run \
+    #       --with exchange-calendars \
+    #       --refresh-package exchange-calendars \
+    #       --index https://test.pypi.org/simple \
+    #       --index https://pypi.org/simple \
+    #       --index-strategy unsafe-best-match \
+    #       --no-project \
+    #       --isolated \
+    #       -- \
+    #       python -c 'import exchange_calendars; print(f"{exchange_calendars.__version__=}")'
 
     - name: Publish distribution 📦 to PyPI
       run: uv publish

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ documentation = "https://github.com/gerrymanoim/exchange_calendars/tree/master/d
 "Source Code" = "https://github.com/gerrymanoim/exchange_calendars"
 
 [tool.uv]
+trusted-publishing = "always"
 conflicts = [
     [
       { group = "test_min" },


### PR DESCRIPTION
Sets `uv` option `trusted-publishing` to "always".

Also removes publishing to testPyPI from release workflow (intended that this be later reinstated).