### PR TITLE
Fix tz of schedule data with pandas 3.0

### DIFF
--- a/exchange_calendars/exchange_calendar.py
+++ b/exchange_calendars/exchange_calendar.py
@@ -2405,7 +2405,7 @@ class ExchangeCalendar(ABC):
             and does not have a time component (or any time component is
             00:00). Otherwise `start` will be interpreted as a time.
 
-            If `period` is one day ("1d") then `start` must be passed as
+            If `period` is one day ("1D") then `start` must be passed as
             a date. The first indice will be either `start`, if `start` is
             a session, or otherwise the nearest session following `start`.
 
@@ -2444,9 +2444,9 @@ class ExchangeCalendar(ABC):
 
             Examples of valid `period` input:
                 pd.Timedelta(minutes=15), pd.Timedelta(minutes=15, hours=2)
-                '15min', '15T', '1H', '4h', '1d', '30s', '2s', '500ms'.
+                '15min', '15T', '1H', '4h', '1D', '30s', '2s', '500ms'.
             Examples of invalid `period` input:
-                '15minutes', '2d'.
+                '15minutes', '2D'.
 
         intervals : default: True
             True to return trading index as a pd.IntervalIndex with indices
@@ -2456,11 +2456,11 @@ class ExchangeCalendar(ABC):
             indices that implicitely represent a period according to
             `closed`.
 
-            If `period` is '1d' then trading index will be returned as a
+            If `period` is '1D' then trading index will be returned as a
             pd.DatetimeIndex.
 
         closed : {"left", "right", "both", "neither"}
-            (ignored if `period` is '1d'.)
+            (ignored if `period` is '1D'.)
 
             If `intervals` is True, the side that intervals should be
             closed on. Must be either "left" or "right" (any time during a
@@ -2484,7 +2484,7 @@ class ExchangeCalendar(ABC):
 
         force_close : default: False
             (ignored if `force` is passed.)
-            (ignored if `period` is '1d')
+            (ignored if `period` is '1D')
             (irrelevant if `intervals` is False and `closed` is "left" or
             "neither")
 
@@ -2499,7 +2499,7 @@ class ExchangeCalendar(ABC):
 
         force_break_close : default: False
             (ignored if `force` is passed.)
-            (ignored if `period` is '1d'.)
+            (ignored if `period` is '1D'.)
             (irrelevant if `intervals` is False and `closed` is "left" or
             "neither.)
 
@@ -2513,7 +2513,7 @@ class ExchangeCalendar(ABC):
             non-trading period.
 
         force : optional
-            (ignored if `period` is '1d'.)
+            (ignored if `period` is '1D'.)
             (irrelevant if `intervals` is False and `closed` is "left" or
             "neither.)
 
@@ -2522,7 +2522,7 @@ class ExchangeCalendar(ABC):
             `force_close` and `force_break_close` will be ignored.
 
         curtail_overlaps : default: False
-            (ignored if `period` is '1d')
+            (ignored if `period` is '1D')
             (irrelevant if (`intervals` is False) or (`force_close` and
             `force_break_close` are both True).)
 
@@ -2539,7 +2539,7 @@ class ExchangeCalendar(ABC):
                 If False, will raise IntervalsOverlapError.
 
         ignore_breaks : default: False
-            (ignored if `period` is '1d')
+            (ignored if `period` is '1D')
             (irrelevant if no session has a break)
 
             Defines whether trading index should respect session breaks.
@@ -2604,7 +2604,7 @@ class ExchangeCalendar(ABC):
         pd.IntervalIndex or pd.DatetimeIndex
             Trading index.
 
-            If `intervals` is False or `period` is '1d' then returned as a
+            If `intervals` is False or `period` is '1D' then returned as a
                 pd.DatetimeIndex.
             If `intervals` is True (default) returned as pd.IntervalIndex.
 
@@ -2635,7 +2635,7 @@ class ExchangeCalendar(ABC):
                     f"`period` receieved as '{period}' although takes type"
                     " 'pd.Timedelta' or a 'str' that is valid as a single input"
                     " to 'pd.Timedelta'. Examples of valid input: pd.Timestamp('15T'),"
-                    " '15min', '15T', '1H', '4h', '1d', '5s', 500ms'."
+                    " '15min', '15T', '1H', '4h', '1D', '5s', 500ms'."
                 )
                 raise ValueError(msg) from None
 

--- a/tests/test_calendar_helpers.py
+++ b/tests/test_calendar_helpers.py
@@ -1756,10 +1756,10 @@ class TestTradingIndex:
         cal, start, end = cal_start_end
         error_msg = (
             "`period` cannot be greater than one day although received as"
-            f" '{pd.Timedelta('2d')}'."
+            f" '{pd.Timedelta('2D')}'."
         )
         with pytest.raises(ValueError, match=error_msg):
-            cal.trading_index(start, end, "2d", parse=False)
+            cal.trading_index(start, end, "2D", parse=False)
 
         error_msg = "If `intervals` is True then `closed` cannot be 'neither'."
         with pytest.raises(ValueError, match=re.escape(error_msg)):
@@ -1791,7 +1791,7 @@ class TestTradingIndex:
             f"`period` receieved as '{invalid_str}' although takes type"
             " 'pd.Timedelta' or a 'str' that is valid as a single input"
             " to 'pd.Timedelta'. Examples of valid input: pd.Timestamp('15T'),"
-            " '15min', '15T', '1H', '4h', '1d', '5s', 500ms'."
+            " '15min', '15T', '1H', '4h', '1D', '5s', 500ms'."
         )
         with pytest.raises(ValueError, match=re.escape(error_msg)):
             cal.trading_index(start, end, invalid_str)


### PR DESCRIPTION
Further revision to support pandas 3.0.

Ensures that all schedule columns continue to have tz as `ZoneInfo("UTC")` rather than being forced by pandas 3.0 to `datetime.timezone.UTC `.

Also fixes pandas 3.0 deprecation warnings.