### PR TITLE
Fix incorrect business day range calculation across weekmask changes under certain conditions.

### DIFF
--- a/exchange_calendars/pandas_extensions/offsets.py
+++ b/exchange_calendars/pandas_extensions/offsets.py
@@ -142,32 +142,44 @@ class CompositeCustomBusinessDay(CustomBusinessDay):
         )
 
     @apply_wraps
-    def _apply(self, other):
-        if isinstance(other, datetime):
+    def _apply(self, day):
+        if isinstance(day, datetime):
+            sign = 1 if self.n > 0 else -1
             moved = 0
             remaining = self.n - moved
-            bday, interval = self._custom_business_day_for(
-                other, remaining, with_interval=True
+            is_edge: bool = (
+                False  # Whether the current day is at the edge of the current interval.
             )
-            result = bday + other
-            while not interval.left <= result <= interval.right:
-                previous_other = other
-                if result < interval.left:
-                    other = interval.left
-                elif result > interval.right:
-                    other = interval.right
+            while remaining != 0:
+                # Get business day and interval for current date. Set is_edge to True if
+                # the day is at the edge of the current interval, so the call returns
+                # the next adjacent interval.
+                bday, interval = self._custom_business_day_for(
+                    day, remaining, with_interval=True, is_edge=is_edge
+                )
+                # Next business day according to current interval.
+                day_next = bday + day
+                # Check if this falls outside the current interval.
+                if interval.left <= day_next <= interval.right:
+                    # Still in the current interval. Continue with next iteration.
+                    moved += sign * max(
+                        1, abs(int(self._moved(day, day_next, bday)))
+                    )  # Must have moved at least one business day.
+                    remaining = self.n - moved
+                    day = day_next
+                    is_edge = False
+                    continue
+                # Next day is outside the current interval. Clamp to interval bounds
+                #  so when re-entering the loop, the next interval is considered.
+                if day_next < interval.left:
+                    day = interval.left
+                elif day_next > interval.right:
+                    day = interval.right
                 else:
                     raise RuntimeError("Should not reach here")
-                moved += self._moved(previous_other, other, bday)
-                remaining = self.n - moved
-                if remaining == 0:
-                    break
-                bday, interval = self._custom_business_day_for(
-                    other, remaining, is_edge=True, with_interval=True
-                )
-                result = bday._apply(other)  # noqa: SLF001
-            return result
-        return super().apply(other)
+                is_edge = True
+            return day
+        return super().apply(day)
 
     # backwards compat
     apply = _apply

--- a/tests/pandas_extensions/test_offsets.py
+++ b/tests/pandas_extensions/test_offsets.py
@@ -1,0 +1,43 @@
+import pandas as pd
+
+from exchange_calendars.exchange_calendar import HolidayCalendar
+from exchange_calendars.pandas_extensions.offsets import (
+    MultipleWeekmaskCustomBusinessDay,
+)
+
+
+def test_weekmask_transition_edge_case():
+    """Checks that date ranges across transitions from one weekmask to another work
+    correctly in the following scenario: When transitioning from one weekmask period to
+    the following, the first business day in the new period, according to the previous
+    period's weekmask, is not the first business day in the new period, according to the
+    second period.
+    """
+
+    # A business day with two weekmask periods. The first business day 2023-07-03 after
+    # the last one 2023-06-30 according to the first period is 2023-07-03, but the
+    # actual first business day in second period is 2023-07-02.
+    bday = MultipleWeekmaskCustomBusinessDay(
+        holidays=[],
+        calendar=HolidayCalendar(rules=[]),
+        weekmask="1111100",
+        weekmasks=[
+            (None, pd.Timestamp("2023-07-01"), "1111100"),
+            (pd.Timestamp("2023-07-02"), None, "0000011"),
+        ],
+    )
+
+    # Check business days in range around transition point.
+    assert pd.date_range(
+        pd.Timestamp("2023-06-29"), pd.Timestamp("2023-07-11"), freq=bday
+    ).equals(
+        pd.DatetimeIndex(
+            data=[
+                pd.Timestamp("2023-06-29"),
+                pd.Timestamp("2023-06-30"),  # Last business day in first period.
+                pd.Timestamp("2023-07-02"),  # First business day in second period.
+                pd.Timestamp("2023-07-08"),
+                pd.Timestamp("2023-07-09"),
+            ]
+        )
+    )


### PR DESCRIPTION
This PR is to fix an issue with the class `CompositeCustomBusinessDay` where it's possible that business day ranges across weekmask changes are not calculated correctly.

Apparently, the class is used today only as a base class for `MultipleWeekmaskCustomBusinessDay` which in turn is used by select calendars (XBOM, XKRX, XMOS, XTAE) with different weekmasks over time.

The specific issue that this PR addresses does not seem to affect these calendars, owing to the kind of weekmasks and transition dates used. However, in the general case, the implementation of `CompositeCustomBusinessDay` seems to be incorrect.

The conditions under which the bug is exposed are as follows: A business day range is calculated across a transition from one weekmask to another and the first business day in the second period, according to the weekmask of the first period (say `x_1`), and according to the second period (say `x_2`), respectively, are not identical.

The reason for this is the following line of code from `CompositeCustomBusinessDay`'s `_apply()` method:

```python
moved += self._moved(previous_other, other, bday)
```

In the mentioned scenarios, this returns `1` when the last business day in the first period is not the last day in the period itself. This in turn causes the following code to exit from a loop prematurely:

```python
remaining = self.n - moved
if remaining == 0:
    break
```

The method then returns the `result` which was calculated before as the next business day relative to the input date and according to the first period's weekmask. This is incorrect, if the next business day falls into the second period, but it's not actually the first business day in that period.

To illustrate, I have added a test in `tests.pandas_extensions.test_offsets`. This testcase fails if the suggested fix to `_apply` contained in this PR is removed.

Finally, I think the code in `_apply()` may have some potential to be simplified, including the call to `self._moved()`. I haven't done this yet since I wanted to find a fix first and the test coverage of `CompositeCustomBusinessDay` seems thin.

But given that business days are generated by repeatedly rolling forward, it seems the `while` loop could be simplified. For as long as the entry condition is satisfied, it should be impossible to have successfully rolled forward by a business day since the current target `other` is already in the next period where it needs to be re-evaluated again according to the prevailing weekmask there.