### PR TITLE
Fix special_opens type hint, fix pre-commit config.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,15 @@
 repos:
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v6.0.0
-  hooks:
-    - id: check-yaml
-    - id: end-of-file-fixer
-    - id: trailing-whitespace
-  repo: https://github.com/astral-sh/ruff-pre-commit
-  # Ruff version.
-  rev: v0.13.0
-  hooks:
-    # Run the linter.
-    - id: ruff-check
-    # Run the formatter.
-    - id: ruff-format
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.13.0
+    hooks:
+      # Run the linter.
+      - id: ruff-check
+      # Run the formatter.
+      - id: ruff-format

--- a/exchange_calendars/exchange_calendar.py
+++ b/exchange_calendars/exchange_calendar.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
-from calendar import day_name
 import collections
 import functools
 import operator
-from typing import TYPE_CHECKING, Literal, Any
 import warnings
+from abc import ABC, abstractmethod
+from calendar import day_name
+from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 import pandas as pd
@@ -28,10 +28,11 @@ from pandas.tseries.holiday import AbstractHolidayCalendar
 from pandas.tseries.offsets import CustomBusinessDay
 
 from exchange_calendars import errors
+
 from .calendar_helpers import (
-    UTC,
     NANOSECONDS_PER_MINUTE,
     NP_NAT,
+    UTC,
     Date,
     Minute,
     Session,
@@ -50,9 +51,10 @@ from .calendar_helpers import (
 from .utils.pandas_utils import days_at_time
 
 if TYPE_CHECKING:
-    from zoneinfo import ZoneInfo
     import datetime
-    from collections.abc import Sequence, Callable
+    from collections.abc import Callable, Sequence
+    from zoneinfo import ZoneInfo
+
     from pandas._libs.tslibs.nattype import NaTType
 
 
@@ -604,7 +606,7 @@ class ExchangeCalendar(ABC):
         return []
 
     @property
-    def special_opens(self) -> list[tuple[datetime.time, HolidayCalendar] | int]:
+    def special_opens(self) -> list[tuple[datetime.time, HolidayCalendar | int]]:
         """Regular non-standard open times.
 
         Example of what would be defined as a special open:

--- a/ruff.toml
+++ b/ruff.toml
@@ -40,7 +40,7 @@ indent-width = 4
 # Assume Python 3.10
 target-version = "py310"
 
-[lint]  
+[lint]
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`) codes by default.
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
 # McCabe complexity (`C901`) by default.


### PR DESCRIPTION
This PR fixes the incorrect type hint on the `special_opens` property. No functional changes, just fixing the hint which had a misplaced `]`; see also correct type hint for `special_closes`.

Other changes in the Python source are purely owing to re-formatting when running the pre-commit hooks.

Finally, I also noticed that the pre-commit config also had a syntax error, so fixed that as well here.