### PR TITLE
XKAR: add Pakistan Stock Exchange 2026 Eid-ul-Azha and Ashura holidays

### DIFF
--- a/exchange_calendars/exchange_calendar_xkar.py
+++ b/exchange_calendars/exchange_calendar_xkar.py
@@ -296,6 +296,9 @@ class XKARExchangeCalendar(ExchangeCalendar):
             "2025-06-07",
             "2025-06-08",
             "2025-06-09",
+            # 2026-05-28 (12 Zil-Haj) is covered by the Youm-e-Takbeer rule.
+            "2026-05-27",
+            "2026-05-29",
         ]
     )
 
@@ -339,6 +342,8 @@ class XKARExchangeCalendar(ExchangeCalendar):
             "2024-07-17",
             "2025-07-05",
             "2025-07-06",
+            "2026-06-25",
+            "2026-06-26",
         ]
     )
 


### PR DESCRIPTION
### Summary

The Pakistan Stock Exchange (XKAR) hard-coded Islamic holiday lists stop at 2025, so several 2026 closures are missing.

Adds the 2026 dates that are genuine gaps (verified against PSX 2026 holiday notices):

- **Eid-ul-Azha** (10th–12th Zil-Hajj): `2026-05-27` and `2026-05-29`. (`2026-05-28` is already covered by the existing `Youm-e-Takbeer` rule, so it is intentionally not duplicated.)
- **Ashura** (9th & 10th Muharram): `2026-06-25` and `2026-06-26`.

(Eid-ul-Fitr 2026 is not a gap — its only weekday, `2026-03-23`, coincides with the existing `Pakistan Day` rule.)

### Verification

```python
import exchange_calendars as xc, pandas as pd
c = xc.get_calendar("XKAR")
[c.is_session(pd.Timestamp(d)) for d in
 ("2026-05-27","2026-05-28","2026-05-29","2026-06-25","2026-06-26")]
# all False (closed); 2026-06-24 remains a session
```

`tests/test_xkar_calendar.py` passes (143 passed). The answers CSV currently ends in 2025, so these dates aren't in it yet; happy to extend/regenerate it if you'd prefer.

### Source

PSX 2026 holiday notices (Eid-ul-Azha May 27–29; Ashura June 25–26).