### PR TITLE
Fix XHKG NumPy timedelta deprecation

### DIFF
--- a/exchange_calendars/exchange_calendar_xhkg.py
+++ b/exchange_calendars/exchange_calendar_xhkg.py
@@ -360,7 +360,7 @@ class XHKGExchangeCalendar(PrecomputedExchangeCalendar):
             qingming_festival_dates,
         ).values.copy()  # copy so that array is writeable
         years = qingming_festival.astype("M8[Y]")
-        easter_monday = EasterMonday.dates(years[0], years[-1] + 1)
+        easter_monday = EasterMonday.dates(years[0], years[-1] + np.timedelta64(1, "Y"))
         # qingming gets observed one day later if easter monday is on the same
         # day
         qingming_festival[qingming_festival == easter_monday] += np.timedelta64(1, "D")

--- a/tests/test_xhkg_calendar.py
+++ b/tests/test_xhkg_calendar.py
@@ -6,6 +6,15 @@ from .test_exchange_calendar import ExchangeCalendarTestBase
 from .test_utils import T
 
 
+@pytest.mark.filterwarnings(
+    "error:The 'generic' unit for NumPy timedelta is deprecated"
+)
+def test_initialization_does_not_use_generic_numpy_timedelta():
+    calendar = XHKGExchangeCalendar()
+
+    assert calendar.name == "XHKG"
+
+
 class TestXHKGCalendar(ExchangeCalendarTestBase):
     @pytest.fixture(scope="class")
     @classmethod


### PR DESCRIPTION
## Summary

- replace bare integer arithmetic on a NumPy year-resolution datetime with an
  explicit one-year `timedelta64`
- add an XHKG initialization regression test that promotes the affected NumPy
  deprecation warning to an error

## Root cause

The XHKG Qingming/Easter Monday overlap calculation used
`years[-1] + 1`. NumPy 2.5 deprecates the implicit conversion of that bare
integer to a generic-unit timedelta and plans to make it an error.

Using `np.timedelta64(1, "Y")` preserves the intended one-year upper bound
while making the unit explicit.

## Impact

Constructing the XHKG calendar no longer emits the NumPy generic-timedelta
deprecation warning. The calculated Easter Monday range and XHKG holiday
dates are unchanged, so no calendar resource update is required.

## Validation

- regression test failed on upstream `master` with the targeted
  `DeprecationWarning`, then passed with this change
- `pytest -q -W error::DeprecationWarning tests/test_xhkg_calendar.py`:
  143 passed
- legacy and explicit calculations returned the same 90 Easter Monday dates
  from 1960-04-18 through 2049-04-19
- pre-commit hooks passed for both changed files, including Ruff lint and
  formatting
