### PR TITLE
Update Claude agent files

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,7 @@
 {
   "permissions": {
     "allow": [
-      "Edit(./.pre-commit-config.yaml)",
+      "Edit(.pre-commit-config.yaml)",
       "Edit(.github/workflows/build-test.yml)",
       "Edit(.github/workflows/draft-release-notes.yml)",
       "Edit(.github/workflows/release.yml)",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,3 +9,16 @@ The remaining content of this file is intended only for Claude (including Claude
 Find skills under the @.agents/skills directory which serves as the directory you would have expected to find at `.claude/skills`.
 
 Your name is Claude. Anywhere in the context that asks you to use your 'name' or 'colloquial name' or 'vernacular name' then you should use 'Claude'.
+
+## Editing files with pre-granted permissions
+
+`.claude/settings.json` pre-grants `Edit(...)` permission for a specific set of
+files (e.g. `.pre-commit-config.yaml` and github workflows/*.yml` files). These
+permissions only apply to the built-in`Edit` tool — they do not extend to the
+`Bash` tool.
+
+Some routines (e.g. the `dependencies-management` routine) are configured to run
+automatically and unattended and in these cases a permission prompt would stall
+the run. Therefore, when modifying any file covered by the `Edit(...)` permissions in
+`.claude/settings.json`, **always use the `Edit` tool** (not `Bash`/`sed`/etc.) so
+that the pre-granted permission applies and no prompt is raised.


### PR DESCRIPTION
Updates Claude agent files to, effectively, not request edit permission for files granted edit permission in `.claude/settings.json` settings. This prevents automated `dependency-management` routines from stalling.