### PR TITLE
Fix XKRX late_opens for special offsets

### DIFF
--- a/exchange_calendars/exchange_calendar.py
+++ b/exchange_calendars/exchange_calendar.py
@@ -353,7 +353,11 @@ class ExchangeCalendar(ABC):
         )
 
         # Apply any special offsets first
+        assert self._opens is not None
+        _standard_opens = self._opens.copy()
         self.apply_special_offsets(_all_days, start, end)
+        assert self._opens is not None
+        _special_offset_late_opens = _all_days[self._opens > _standard_opens]
 
         # Series mapping sessions with non-standard opens/closes.
         _special_opens = self._calculate_special_opens(start, end)
@@ -412,11 +416,12 @@ class ExchangeCalendar(ABC):
         # NOTE If / when min pandas bumps to 2.0 can reduce all the following to just
         # the content of the if clause. (`as_unit`` introduced in pandas 2.0).
         # NB pre v3.0 pandas infers resolution here as "ns", not so in v3.
+        _late_opens = _special_opens.index.union(_special_offset_late_opens)
         if pd.__version__ >= "3.0.0":
-            self._late_opens = _special_opens.index.as_unit("ns")
+            self._late_opens = _late_opens.as_unit("ns")
             self._early_closes = _special_closes.index.as_unit("ns")
         else:
-            self._late_opens = _special_opens.index
+            self._late_opens = _late_opens
             self._early_closes = _special_closes.index
 
     # --------------- Calendar definition methods/properties --------------

--- a/tests/test_xkrx_calendar.py
+++ b/tests/test_xkrx_calendar.py
@@ -108,12 +108,6 @@ class TestXKRXCalendar(ExchangeCalendarTestBase):
             "2026-06-03",  # Local election day.
         ]
 
-    # TODO: Issue #94
-    def test_late_opens(self, default_calendar, late_opens):  # noqa: ARG002
-        # overrides base to mark as xfail
-        msg = "Calendar has late opens although `late_opens` is empty. Issue #94"
-        pytest.xfail(msg)
-
     # Calendar-specific tests
 
     def test_historical_regular_holidays_fall_into_precomputed_holidays(


### PR DESCRIPTION
## Summary

`XKRX` applies CSAT and first-session delays through `apply_special_offsets()`. Those offsets already change the generated schedule, but `late_opens` was populated only from `special_opens`, leaving it empty despite the delayed sessions.

This records the standard opens before the hook runs and adds only sessions whose offset-adjusted open is actually later. Existing `special_opens` remain authoritative and are unioned with those sessions. The XKRX override that marked the shared late-open check as expected failure is removed, so the full calendar answer data now verifies the property.

Fixes #94

## Validation

- `uv run pytest -q --capture=no tests/test_xkrx_calendar.py` — 144 passed
- `uv run pytest -q --capture=no tests/test_bvmf_calendar.py` — 142 passed
- `uvx ruff==0.16.3 format --check exchange_calendars/exchange_calendar.py tests/test_xkrx_calendar.py`
- `uvx ruff==0.16.3 check exchange_calendars/exchange_calendar.py tests/test_xkrx_calendar.py`

The schedule and XKRX resource CSV are unchanged; this corrects only the derived `late_opens` metadata.
